### PR TITLE
Enhance the msquares example to show that there are 2 different meshes.

### DIFF
--- a/examples/par_msquare/main.cc
+++ b/examples/par_msquare/main.cc
@@ -254,6 +254,7 @@ void BuildCameraFrame(float3 &corner, float3 &du, float3 &dv, const float3 &eye,
 typedef struct {
   std::vector<float> vertices;
   std::vector<unsigned int> faces;
+  std::vector<int> facegroups;
 } Mesh;
 
 bool BuildMSQ(Mesh &meshOut, int &imgW, int &imgH, const char *filename) {
@@ -286,8 +287,11 @@ bool BuildMSQ(Mesh &meshOut, int &imgW, int &imgH, const char *filename) {
 
   assert(numMeshes > 0);
   size_t vtxoffset = 0;
+  int ntriangles = 0;
   for (int m = 0; m < numMeshes; m++) {
     par_msquares_mesh const *mesh = par_msquares_get_mesh(mlist, m);
+    meshOut.facegroups.push_back(ntriangles);
+    ntriangles += mesh->ntriangles;
     printf("numTriangles = %d\n", mesh->ntriangles);
     printf("numVerts = %d\n", mesh->npoints);
     printf("dim = %d\n", mesh->dim);
@@ -564,6 +568,13 @@ int main(int argc, char **argv) {
 
             float3 aoCol = ShadeAO(P, N, &rng, accel, &mesh.vertices.at(0),
                                    &mesh.faces.at(0));
+            if (fid < mesh.facegroups[1]) {
+                // Ocean
+                aoCol = aoCol.x * float3(0,0.25,0.5);
+            } else {
+                // Land
+                aoCol = aoCol.x * float3(0,0.9,0.5);
+            }
             rgb[3 * (y * width + x) + 0] = aoCol[0];
             rgb[3 * (y * width + x) + 1] = aoCol[1];
             rgb[3 * (y * width + x) + 2] = aoCol[2];


### PR DESCRIPTION
I love nanort!  I want to try using it in conjunction with Amazon Lambda...

Anyway I thought it would be cool to enhance this example just a little, since the neat thing about my marching squares implementation is that it provides nice boundaries between adjoining meshes.  I changed the example to use different color for the two meshes.  Here is the result of my change:

![render](https://cloud.githubusercontent.com/assets/1288904/11677332/6094008a-9df1-11e5-9c1d-89f097db491b.png)
