### PR TITLE
cmake file for gui example

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,13 @@ platform: x64
 configuration: Release
 
 before_build:
+  - cd C:\projects
+  - nuget install nupengl.core
+  - cd C:\projects\nanort
   - echo running cmake...
   - cmake -G "Visual Studio 12 Win64" -Bbuild -H.
+    -DGLEW_INCLUDE_DIR="C:\projects\nupengl.core.0.1.0.1\build\native\include"
+    -DGLEW_LIBRARY="C:\projects\nupengl.core.0.1.0.1\build\native\lib\x64\glew32.lib"
 
 build:
   parallel: true

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(bidir_path_tracer)
+add_subdirectory(gui)
 add_subdirectory(path_tracer)

--- a/examples/gui/CMakeLists.txt
+++ b/examples/gui/CMakeLists.txt
@@ -1,0 +1,45 @@
+set(BUILD_TARGET "gui")
+
+find_package(GLEW REQUIRED)
+find_package(OpenGL REQUIRED)
+find_package(X11 REQUIRED)
+
+include_directories(${GLEW_INCLUDE_DIR})
+include_directories(${OPENGL_INCLUDE_DIR})
+include_directories(${X11_INCLUDE_DIR})
+
+include_directories(${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/examples/common")
+include_directories(${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/examples/common/imgui")
+
+set(SOURCES
+    main.cc
+    render.cc
+    render-config.cc
+    ../common/trackball.cc
+    matrix.cc
+    ../common/imgui/imgui.cpp
+    ../common/imgui/imgui_draw.cpp
+    ../common/imgui/imgui_impl_btgui.cpp
+)
+
+if(WIN32)
+    set(SOURCES ${SOURCES}
+        ../common/OpenGLWindow/Win32OpenGLWindow.cpp
+        ../common/OpenGLWindow/Win32Window.cpp
+    )
+elseif(APPLE)
+    set(SOURCES ${SOURCES} ../common/OpenGLWindow/MacOpenGLWindow.mm)
+else()
+    set(SOURCES ${SOURCES} ../common/OpenGLWindow/X11OpenGLWindow.cpp)
+endif()
+
+add_executable(${BUILD_TARGET} ${SOURCES})
+
+target_link_libraries(
+    ${BUILD_TARGET}
+    ${GLEW_LIBRARIES}
+    ${OPENGL_LIBRARIES}
+    ${X11_LIBRARIES}
+)
+
+source_group("Source Files" FILES ${SOURCES})

--- a/examples/gui/main.cc
+++ b/examples/gui/main.cc
@@ -66,6 +66,11 @@ THE SOFTWARE.
 #include "render.h"
 #include "trackball.h"
 
+#ifdef WIN32
+#undef min
+#undef max
+#endif
+
 #define SHOW_BUFFER_COLOR (0)
 #define SHOW_BUFFER_NORMAL (1)
 #define SHOW_BUFFER_POSITION (2)

--- a/examples/gui/render.cc
+++ b/examples/gui/render.cc
@@ -45,6 +45,11 @@ THE SOFTWARE.
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
+#ifdef WIN32
+#undef min
+#undef max
+#endif
+
 namespace example {
 
 // PCG32 code / (c) 2014 M.E. O'Neill / pcg-random.org


### PR DESCRIPTION
Would you accept a simple cmake file for the GUI example? Wanted to try this but had no premake4 under Ubuntu 14.04 right away.

Btw. I can't use it in debug mode because ImGUI asserts that a true type file exists:
```
gui: /home/zellmans/nanort/examples/common/imgui/imgui_draw.cpp:1196: ImFont* ImFontAtlas::AddFontFromFileTTF(const char*, float, const ImFontConfig*, const ImWchar*): Assertion `0' failed.
Aborted (core dumped)
```

Simply deleting the assert() would do. This is however an issue in a 3rdparty lib and not directly in nanort..