### PR TITLE
fix many updates for non-"color" shader. fix many samples problem

### DIFF
--- a/examples/common/picojson.h
+++ b/examples/common/picojson.h
@@ -744,6 +744,19 @@ namespace picojson {
     }
     do {
       std::string key;
+	  
+	  //tigra: can handle // comment!
+	  if(in.expect('/'))
+	  {
+		  if(in.expect('/'))
+		  {
+			 int ch;
+			 do {ch = in.getc();} while(ch==10 || ch==13);
+
+			 in.ungetc();			 
+		  }
+	  }	    
+	    
       if (! in.expect('"')
 	  || ! _parse_string(key, in)
 	  || ! in.expect(':')) {

--- a/examples/nanosg/main.cc
+++ b/examples/nanosg/main.cc
@@ -912,6 +912,7 @@ int main(int argc, char** argv) {
 	  if(gShowBufferMode_prv!=gShowBufferMode)
 	  {
 		  gRenderConfig.pass = 0;
+		  gShowBufferMode_prv = gShowBufferMode;
 	  }
 
 

--- a/examples/nanosg/main.cc
+++ b/examples/nanosg/main.cc
@@ -96,19 +96,16 @@ THE SOFTWARE.
 #endif
 #endif
 
-#define SHOW_BUFFER_COLOR (0)
-#define SHOW_BUFFER_NORMAL (1)
-#define SHOW_BUFFER_POSITION (2)
-#define SHOW_BUFFER_DEPTH (3)
-#define SHOW_BUFFER_TEXCOORD (4)
-#define SHOW_BUFFER_VARYCOORD (5)
-
 b3gDefaultOpenGLWindow* window = 0;
 int gWidth = 512;
 int gHeight = 512;
 int gMousePosX = -1, gMousePosY = -1;
 bool gMouseLeftDown = false;
+
+//FIX issue when max passes is done - no modes is switched. pass must be set to 0 when mode is changed
+int gShowBufferMode_prv = SHOW_BUFFER_COLOR;
 int gShowBufferMode = SHOW_BUFFER_COLOR;
+
 bool gTabPressed = false;
 bool gShiftPressed = false;
 float gShowPositionScale = 1.0f;
@@ -203,7 +200,10 @@ void RenderThread() {
 
     bool ret =
         example::Renderer::Render(&gRenderLayer.rgba.at(0), &gRenderLayer.auxRGBA.at(0), &gRenderLayer.sampleCounts.at(0),
-                         gCurrQuat, gScene, gAsset, gRenderConfig, gRenderCancel);
+                         gCurrQuat, gScene, gAsset, gRenderConfig, gRenderCancel
+                                 ,
+						                    gShowBufferMode //added mode passing
+                                 );
 
     if (ret) {
       std::lock_guard<std::mutex> guard(gMutex);
@@ -907,6 +907,12 @@ int main(int argc, char** argv) {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
     checkErrors("clear");
+	
+    //fix max passes issue
+	  if(gShowBufferMode_prv!=gShowBufferMode)
+	  {
+		  gRenderConfig.pass = 0;
+	  }
 
 
     // Render display window

--- a/examples/nanosg/render.cc
+++ b/examples/nanosg/render.cc
@@ -235,7 +235,9 @@ bool Renderer::Render(float* rgba, float* aux_rgba, int* sample_counts,
                       const nanosg::Scene<float, example::Mesh<float>> &scene,
                       const example::Asset &asset,
                       const RenderConfig& config,
-                      std::atomic<bool>& cancelFlag) {
+                      std::atomic<bool>& cancelFlag,
+                      int &_showBufferMode
+                      ) {
   //if (!gAccel.IsValid()) {
   //  return false;
   //}
@@ -300,6 +302,19 @@ bool Renderer::Render(float* rgba, float* aux_rgba, int* sample_counts,
           float u1 = pcg32_random(&rng);
 
           float3 dir;
+        
+        //for modes not a "color"
+		    if(_showBufferMode != SHOW_BUFFER_COLOR)
+		    {
+          //only one pass
+			    if(config.pass > 0)
+				    continue;
+				  
+          //to the center of pixel
+			      u0 = 0.5f;
+			      u1 = 0.5f;
+		      }
+      
           dir = corner + (float(x) + u0) * u +
                 (float(config.height - y - 1) + u1) * v;
           dir = vnormalize(dir);

--- a/examples/nanosg/render.h
+++ b/examples/nanosg/render.h
@@ -3,6 +3,15 @@
 
 #include <atomic>  // C++11
 
+//mode definitions now here 
+
+#define SHOW_BUFFER_COLOR (0)
+#define SHOW_BUFFER_NORMAL (1)
+#define SHOW_BUFFER_POSITION (2)
+#define SHOW_BUFFER_DEPTH (3)
+#define SHOW_BUFFER_TEXCOORD (4)
+#define SHOW_BUFFER_VARYCOORD (5)
+
 #include "render-config.h"
 #include "nanosg.h"
 #include "mesh.h"
@@ -23,7 +32,10 @@ class Renderer {
 
   /// Returns false when the rendering was canceled.
   static bool Render(float* rgba, float* aux_rgba, int *sample_counts, float quat[4],
-              const nanosg::Scene<float, Mesh<float>> &scene, const Asset &asset, const RenderConfig& config, std::atomic<bool>& cancel_flag);
+              const nanosg::Scene<float, Mesh<float>> &scene, const Asset &asset, const RenderConfig& config,
+                     std::atomic<bool>& cancel_flag,
+                     int& _showBufferMode
+                    );
 };
 };
 


### PR DESCRIPTION
1. fix many updates  for non-"color" shader.
only one sample to center of pixel. result - no jitter for non-"color" shaders

2. was an issue when you switch shader, passes not set to 0 and when total passes is set to max_passes, shaders not switch. FIXED

3. i modify picojson for support of '//' comment