### PR TITLE
Fix PBR example for Linux/GCC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ viwewer.make
 bin/
 *.csv
 build/
+
+.vscode/

--- a/examples/pbr_surface/main.cc
+++ b/examples/pbr_surface/main.cc
@@ -18,7 +18,7 @@
 
 template <typename T>
 glm::vec3 toVec3(T arr) {
-  return { arr[0], arr[1], arr[2] }
+  return { arr[0], arr[1], arr[2] };
 }
 
 template <typename T>

--- a/examples/pbr_surface/pbr_maths.hh
+++ b/examples/pbr_surface/pbr_maths.hh
@@ -9,9 +9,10 @@
 
 namespace pbr_maths {
 
-constexpr static float c_MinRoughness = 0.04;
-constexpr static float M_PI = 3.141592653589793;
-
+constexpr static float const c_MinRoughness = 0.04;
+#ifndef M_PI
+constexpr static float const M_PI = 3.141592653589793;
+#endif
 // GLSL data types
 using glm::mat3;
 using glm::mat4;


### PR DESCRIPTION
As always, Visual Studio let us do thing that will not build on other compiler.

This fixes the PBR CPU shading example on Linux.

Signed-off by: Arthur Brainville (Ybalrid) <ybalrid@ybalrid.info>