### PR TITLE
Pbr templated preceision

### DIFF
--- a/examples/pbr_surface/main.cc
+++ b/examples/pbr_surface/main.cc
@@ -24,7 +24,7 @@
 #include "mesh.h"
 #include "utility.h"
 
-using float_precision = double;
+using float_precision = long double;
 
 void loadSampler(pbr_maths::sampler2D < float_precision >& sampler,
                  const stbi_uc* data, int w,
@@ -85,7 +85,7 @@ void loadSamplerCube(pbr_maths::samplerCube < float_precision  >& cubemap,
 int main() {
   pbr_maths::sampler2D < float_precision > normalMap, baseColorMap, emissiveMap,
       brdfLUT;
-  int w, h, c;
+//  int w, h, c;
   // auto normdata = stbi_load("./MetalPlates02_nrm.jpg", &w, &h, &c, 0);
   // if (normdata) loadSampler(normalMap, normdata, w, h, c);
 

--- a/examples/pbr_surface/main.cc
+++ b/examples/pbr_surface/main.cc
@@ -24,11 +24,14 @@
 #include "mesh.h"
 #include "utility.h"
 
-void loadSampler(pbr_maths::sampler2D& sampler, const stbi_uc* data, int w,
+using float_precision = float;
+
+void loadSampler(pbr_maths::sampler2D < float_precision >& sampler,
+                 const stbi_uc* data, int w,
                  int h, int c) {
   sampler.width = w;
   sampler.height = h;
-  sampler.pixels = new pbr_maths::sampler2D::pixel[w * h];
+  sampler.pixels = new pbr_maths::sampler2D < float_precision >::pixel[w * h];
   sampler.linearFiltering = true;
   for (size_t i = 0; i < w * h; ++i) {
     sampler.pixels[i].r = data[i * c + 0];
@@ -41,14 +44,15 @@ void loadSampler(pbr_maths::sampler2D& sampler, const stbi_uc* data, int w,
 // This permit to load metal and roughness maps from different textures (instead
 // of the standard GREEN/BLUE combined one)  The shader expect theses two maps
 // as a combined one, so we are building it ourselves
-void loadCombineMetalRoughSampler(pbr_maths::sampler2D& sampler,
+void loadCombineMetalRoughSampler(pbr_maths::sampler2D < float_precision  >&
+                                      sampler,
                                   const stbi_uc* metalData, int mw, int mh,
                                   int mc, const stbi_uc* roughnessData, int rw,
                                   int rh, int rc) {
   assert(mw == rw);
   assert(mh == rh);
 
-  sampler.pixels = new pbr_maths::sampler2D::pixel[mw * mh];
+  sampler.pixels = new pbr_maths::sampler2D < float_precision >::pixel[mw * mh];
 
   for (size_t i = 0; i < mw * mh; ++i) {
     // We don't really care about these ones
@@ -61,7 +65,7 @@ void loadCombineMetalRoughSampler(pbr_maths::sampler2D& sampler,
 }
 
 // PLEASE RESPECT ORDER LEFT, RIGHT, UP, DOWN, FRONT, BACK
-void loadSamplerCube(pbr_maths::samplerCube& cubemap,
+void loadSamplerCube(pbr_maths::samplerCube < float_precision  >& cubemap,
                      const std::array<std::string, 6>& files) {
   for (size_t i{0}; i < 6; ++i) {
     cubemap.faces[i].linearFiltering = true;
@@ -79,7 +83,8 @@ void loadSamplerCube(pbr_maths::samplerCube& cubemap,
 }
 
 int main() {
-  pbr_maths::sampler2D normalMap, baseColorMap, emissiveMap, brdfLUT;
+  pbr_maths::sampler2D < float_precision > normalMap, baseColorMap, emissiveMap,
+      brdfLUT;
   int w, h, c;
   // auto normdata = stbi_load("./MetalPlates02_nrm.jpg", &w, &h, &c, 0);
   // if (normdata) loadSampler(normalMap, normdata, w, h, c);
@@ -97,7 +102,7 @@ int main() {
 
   // brdfLUT.boundsOperation = pbr_maths::sampler2D::outOfBounds::clamp;
 
-  pbr_maths::sampler2D metalRoughMap;
+  pbr_maths::sampler2D < float_precision > metalRoughMap;
   // int rw, rh, rc, mw, mh, mc;
   // auto roughData = stbi_load("./MetalPlates02_rgh.jpg", &rw, &rh, &rc, 0);
   // auto metalData = stbi_load("./MetalPlates02_met.jpg", &mw, &mh, &mc, 0);
@@ -105,7 +110,7 @@ int main() {
   //  loadCombineMetalRoughSampler(metalRoughMap, metalData, mw, mh, mc,
   //                               roughData, rw, rh, rc);
 
-  pbr_maths::samplerCube specularEnvMap, diffuseEnvMap;
+  pbr_maths::samplerCube < float_precision >  specularEnvMap, diffuseEnvMap;
 
   loadSamplerCube(diffuseEnvMap, {"diffuse_left_0.jpg", "diffuse_right_0.jpg",
                                   "diffuse_top_0.jpg", "diffuse_bottom_0.jpg",
@@ -165,25 +170,29 @@ int main() {
   if (baseColorIt != textures.end()) {
     loadSampler(baseColorMap, baseColorIt->image, baseColorIt->width,
                 baseColorIt->height, baseColorIt->components);
-    baseColorMap.boundsOperation = pbr_maths::sampler2D::outOfBounds::wrap;
+    baseColorMap.boundsOperation =
+        pbr_maths::sampler2D < float_precision >::outOfBounds::wrap;
   }
 
   if (normalIt != textures.end()) {
     loadSampler(normalMap, normalIt->image, normalIt->width, normalIt->height,
                 normalIt->components);
-    normalMap.boundsOperation = pbr_maths::sampler2D::outOfBounds::wrap;
+    normalMap.boundsOperation =
+        pbr_maths::sampler2D < float_precision>::outOfBounds::wrap;
   }
 
   if (metalRoughIt != textures.end()) {
     loadSampler(metalRoughMap, metalRoughIt->image, metalRoughIt->width,
                 metalRoughIt->height, metalRoughIt->components);
-    metalRoughMap.boundsOperation = pbr_maths::sampler2D::outOfBounds::wrap;
+    metalRoughMap.boundsOperation =
+        pbr_maths::sampler2D < float_precision>::outOfBounds::wrap;
   }
 
   if (emitIt != textures.end()) {
     loadSampler(emissiveMap, emitIt->image, emitIt->width, emitIt->height,
                 emitIt->components);
-    emissiveMap.boundsOperation = pbr_maths::sampler2D::outOfBounds::wrap;
+    emissiveMap.boundsOperation =
+        pbr_maths::sampler2D < float_precision>::outOfBounds::wrap;
   }
 
   for (auto texture : textures) delete[] texture.image;
@@ -289,7 +298,7 @@ int main() {
           if (!accel.Traverse(lightRay, triangle_intersector, &isect)) {
             // This object represent a fragment shader, and is literally a
             // translation in C++ from an official example from khronos
-            pbr_maths::PBRShaderCPU shader;
+            pbr_maths::PBRShaderCPU < float_precision> shader;
 
             // Fill in the uniform/varying variables
             shader.u_Camera.x = camRay.org[0];

--- a/examples/pbr_surface/main.cc
+++ b/examples/pbr_surface/main.cc
@@ -24,7 +24,7 @@
 #include "mesh.h"
 #include "utility.h"
 
-using float_precision = float;
+using float_precision = double;
 
 void loadSampler(pbr_maths::sampler2D < float_precision >& sampler,
                  const stbi_uc* data, int w,

--- a/examples/pbr_surface/main.cc
+++ b/examples/pbr_surface/main.cc
@@ -26,12 +26,11 @@
 
 using float_precision = float;
 
-void loadSampler(pbr_maths::sampler2D < float_precision >& sampler,
-                 const stbi_uc* data, int w,
-                 int h, int c) {
+void loadSampler(pbr_maths::sampler2D<float_precision>& sampler,
+                 const stbi_uc* data, int w, int h, int c) {
   sampler.width = w;
   sampler.height = h;
-  sampler.pixels = new pbr_maths::sampler2D < float_precision >::pixel[w * h];
+  sampler.pixels = new pbr_maths::sampler2D<float_precision>::pixel[w * h];
   sampler.linearFiltering = true;
   for (size_t i = 0; i < w * h; ++i) {
     sampler.pixels[i].r = data[i * c + 0];
@@ -44,15 +43,14 @@ void loadSampler(pbr_maths::sampler2D < float_precision >& sampler,
 // This permit to load metal and roughness maps from different textures (instead
 // of the standard GREEN/BLUE combined one)  The shader expect theses two maps
 // as a combined one, so we are building it ourselves
-void loadCombineMetalRoughSampler(pbr_maths::sampler2D < float_precision  >&
-                                      sampler,
-                                  const stbi_uc* metalData, int mw, int mh,
-                                  int mc, const stbi_uc* roughnessData, int rw,
-                                  int rh, int rc) {
+void loadCombineMetalRoughSampler(
+    pbr_maths::sampler2D<float_precision>& sampler, const stbi_uc* metalData,
+    int mw, int mh, int mc, const stbi_uc* roughnessData, int rw, int rh,
+    int rc) {
   assert(mw == rw);
   assert(mh == rh);
 
-  sampler.pixels = new pbr_maths::sampler2D < float_precision >::pixel[mw * mh];
+  sampler.pixels = new pbr_maths::sampler2D<float_precision>::pixel[mw * mh];
 
   for (size_t i = 0; i < mw * mh; ++i) {
     // We don't really care about these ones
@@ -65,7 +63,7 @@ void loadCombineMetalRoughSampler(pbr_maths::sampler2D < float_precision  >&
 }
 
 // PLEASE RESPECT ORDER LEFT, RIGHT, UP, DOWN, FRONT, BACK
-void loadSamplerCube(pbr_maths::samplerCube < float_precision  >& cubemap,
+void loadSamplerCube(pbr_maths::samplerCube<float_precision>& cubemap,
                      const std::array<std::string, 6>& files) {
   for (size_t i{0}; i < 6; ++i) {
     cubemap.faces[i].linearFiltering = true;
@@ -83,9 +81,9 @@ void loadSamplerCube(pbr_maths::samplerCube < float_precision  >& cubemap,
 }
 
 int main() {
-  pbr_maths::sampler2D < float_precision > normalMap, baseColorMap, emissiveMap,
+  pbr_maths::sampler2D<float_precision> normalMap, baseColorMap, emissiveMap,
       brdfLUT;
-//  int w, h, c;
+  //  int w, h, c;
   // auto normdata = stbi_load("./MetalPlates02_nrm.jpg", &w, &h, &c, 0);
   // if (normdata) loadSampler(normalMap, normdata, w, h, c);
 
@@ -102,7 +100,7 @@ int main() {
 
   // brdfLUT.boundsOperation = pbr_maths::sampler2D::outOfBounds::clamp;
 
-  pbr_maths::sampler2D < float_precision > metalRoughMap;
+  pbr_maths::sampler2D<float_precision> metalRoughMap;
   // int rw, rh, rc, mw, mh, mc;
   // auto roughData = stbi_load("./MetalPlates02_rgh.jpg", &rw, &rh, &rc, 0);
   // auto metalData = stbi_load("./MetalPlates02_met.jpg", &mw, &mh, &mc, 0);
@@ -110,7 +108,7 @@ int main() {
   //  loadCombineMetalRoughSampler(metalRoughMap, metalData, mw, mh, mc,
   //                               roughData, rw, rh, rc);
 
-  pbr_maths::samplerCube < float_precision >  specularEnvMap, diffuseEnvMap;
+  pbr_maths::samplerCube<float_precision> specularEnvMap, diffuseEnvMap;
 
   loadSamplerCube(diffuseEnvMap, {"diffuse_left_0.jpg", "diffuse_right_0.jpg",
                                   "diffuse_top_0.jpg", "diffuse_bottom_0.jpg",
@@ -171,28 +169,28 @@ int main() {
     loadSampler(baseColorMap, baseColorIt->image, baseColorIt->width,
                 baseColorIt->height, baseColorIt->components);
     baseColorMap.boundsOperation =
-        pbr_maths::sampler2D < float_precision >::outOfBounds::wrap;
+        pbr_maths::sampler2D<float_precision>::outOfBounds::wrap;
   }
 
   if (normalIt != textures.end()) {
     loadSampler(normalMap, normalIt->image, normalIt->width, normalIt->height,
                 normalIt->components);
     normalMap.boundsOperation =
-        pbr_maths::sampler2D < float_precision>::outOfBounds::wrap;
+        pbr_maths::sampler2D<float_precision>::outOfBounds::wrap;
   }
 
   if (metalRoughIt != textures.end()) {
     loadSampler(metalRoughMap, metalRoughIt->image, metalRoughIt->width,
                 metalRoughIt->height, metalRoughIt->components);
     metalRoughMap.boundsOperation =
-        pbr_maths::sampler2D < float_precision>::outOfBounds::wrap;
+        pbr_maths::sampler2D<float_precision>::outOfBounds::wrap;
   }
 
   if (emitIt != textures.end()) {
     loadSampler(emissiveMap, emitIt->image, emitIt->width, emitIt->height,
                 emitIt->components);
     emissiveMap.boundsOperation =
-        pbr_maths::sampler2D < float_precision>::outOfBounds::wrap;
+        pbr_maths::sampler2D<float_precision>::outOfBounds::wrap;
   }
 
   for (auto texture : textures) delete[] texture.image;
@@ -298,7 +296,7 @@ int main() {
           if (!accel.Traverse(lightRay, triangle_intersector, &isect)) {
             // This object represent a fragment shader, and is literally a
             // translation in C++ from an official example from khronos
-            pbr_maths::PBRShaderCPU < float_precision> shader;
+            pbr_maths::PBRShaderCPU<float_precision> shader;
 
             // Fill in the uniform/varying variables
             shader.u_Camera.x = camRay.org[0];

--- a/examples/pbr_surface/main.cc
+++ b/examples/pbr_surface/main.cc
@@ -24,7 +24,7 @@
 #include "mesh.h"
 #include "utility.h"
 
-using float_precision = long double;
+using float_precision = float;
 
 void loadSampler(pbr_maths::sampler2D < float_precision >& sampler,
                  const stbi_uc* data, int w,

--- a/examples/pbr_surface/pbr_maths.hh
+++ b/examples/pbr_surface/pbr_maths.hh
@@ -289,10 +289,10 @@ struct PBRShaderCPU {
 #ifdef SRGB_FAST_APPROXIMATION
     t_vec3 linOut = pow(srgbIn.xyz, t_vec3(2.2));
 #else   // SRGB_FAST_APPROXIMATION
-    t_vec3 bLess = step(t_vec3(0.04045), t_vec3(srgbIn));
+    t_vec3 bLess = step(t_vec3(fp_type(0.04045)), t_vec3(srgbIn));
     t_vec3 linOut =
-        mix(t_vec3(srgbIn) / t_vec3(12.92),
-            pow((t_vec3(srgbIn) + t_vec3(0.055)) / t_vec3(1.055), t_vec3(2.4)),
+        mix(t_vec3(srgbIn) / t_vec3(fp_type(12.92)),
+            pow((t_vec3(srgbIn) + t_vec3(fp_type(0.055))) / t_vec3(fp_type(1.055)), t_vec3(fp_type(2.4))),
             bLess);
 #endif  // SRGB_FAST_APPROXIMATION
     return t_vec4(linOut, srgbIn.w);
@@ -311,7 +311,7 @@ struct PBRShaderCPU {
     bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
     bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
     bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
-    return fp_type(bits) * 2.3283064365386963e-10;
+    return fp_type(fp_type(bits) * 2.3283064365386963e-10);
   }
 
   t_vec2 Hammersley(unsigned int i, unsigned int N) {
@@ -321,9 +321,9 @@ struct PBRShaderCPU {
   t_vec3 ImportanceSampleGGX(t_vec2 Xi, fp_type roughness, t_vec3 N) {
     fp_type a = roughness * roughness;
 
-    fp_type phi = 2.0 * M_PI * Xi.x;
-    fp_type cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
-    fp_type sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+    fp_type phi = fp_type(2.0) * fp_type(M_PI) * Xi.x;
+    fp_type cosTheta = sqrt((fp_type(1.0) - Xi.y) / (fp_type(1.0) + (a * a - fp_type(1.0)) * Xi.y));
+    fp_type sinTheta = sqrt(fp_type(1.0) - cosTheta * cosTheta);
 
     // from spherical coordinates to cartesian coordinates
     t_vec3 H;
@@ -343,10 +343,10 @@ struct PBRShaderCPU {
 
   fp_type GeometrySchlickGGX(fp_type NdotV, fp_type roughness) {
     fp_type a = roughness;
-    fp_type k = (a * a) / 2.0;
+    fp_type k = (a * a) / fp_type(2.0);
 
     fp_type nom = NdotV;
-    fp_type denom = NdotV * (1.0 - k) + k;
+    fp_type denom = NdotV * (fp_type(1.0) - k) + k;
 
     return nom / denom;
   }
@@ -360,7 +360,7 @@ struct PBRShaderCPU {
 
   t_vec2 IntegrateBRDF(fp_type NdotV, fp_type roughness, unsigned int samples) {
     t_vec3 V;
-    V.x = sqrt(1.0 - NdotV * NdotV);
+    V.x = sqrt(fp_type(1.0) - NdotV * NdotV);
     V.y = 0.0;
     V.z = NdotV;
 
@@ -383,9 +383,9 @@ struct PBRShaderCPU {
         fp_type G = GeometrySmith(roughness, NoV, NoL);
 
         fp_type G_Vis = (G * VoH) / (NoH * NoV);
-        fp_type Fc = pow(1.0 - VoH, 5.0);
+        fp_type Fc = pow(fp_type(1.0) - VoH, fp_type(5.0));
 
-        A += (1.0 - Fc) * G_Vis;
+        A += (fp_type(1.0) - Fc) * G_Vis;
         B += Fc * G_Vis;
       }
     }
@@ -416,7 +416,7 @@ struct PBRShaderCPU {
       brdf.y = brdf3.y;
     } else {
       brdf = t_vec2(IntegrateBRDF(pbrInputs.NdotV,
-                                  1.0 - pbrInputs.perceptualRoughness,
+                                  fp_type(1.0) - pbrInputs.perceptualRoughness,
                                   brdfResolution));
     }
 

--- a/examples/pbr_surface/pbr_maths.hh
+++ b/examples/pbr_surface/pbr_maths.hh
@@ -75,16 +75,16 @@ struct sampler2D {
     // wrap uvs
     t_vec2 buv;
 
-    auto in_bound = [=](float a) {
+    auto in_bound = [=](fp_type a) {
       switch (boundsOperation) {
         case outOfBounds::clamp:
-          clamp(a, 0.f, 0.99999f);
+          clamp(a, fp_type(0), fp_type(0.99999));
           break;
 
         case outOfBounds::wrap:
-          if (a > 1) a = fmod(a, 1.0f);
+          if (a > 1) a = fmod(a, fp_type(1.0));
           if (a < 0) {
-            a = 1 - fmod(abs(a), 1.0f);
+            a = 1 - fmod(abs(a), fp_type(1.0));
           }
           break;
       }
@@ -161,20 +161,20 @@ struct samplerCube {
   }
 };
 
-/// Get the cooresponding UV and face index of a cubemap from a ray/normal
+/// Get the corresponding UV and face index of a cubemap from a ray/normal
 /// vector
 template <typename fp_type>
 void convert_xyz_to_cube_uv(fp_type x, fp_type y, fp_type z, int* index,
                             fp_type* u, fp_type* v) {
-  float absX = fabs(x);
-  float absY = fabs(y);
-  float absZ = fabs(z);
+  const fp_type absX = fabs(x);
+  const fp_type absY = fabs(y);
+  const fp_type absZ = fabs(z);
 
-  int isXPositive = x > 0 ? 1 : 0;
-  int isYPositive = y > 0 ? 1 : 0;
-  int isZPositive = z > 0 ? 1 : 0;
-
-  float maxAxis, uc, vc;
+  const int isXPositive = x > 0 ? 1 : 0;
+  const int isYPositive = y > 0 ? 1 : 0;
+  const int isZPositive = z > 0 ? 1 : 0;
+ 
+  fp_type maxAxis{}, uc{}, vc{};
 
   // POSITIVE X
   if (isXPositive && absX >= absY && absX >= absZ) {
@@ -318,7 +318,7 @@ struct PBRShaderCPU {
     return t_vec2(fp_type(i) / fp_type(N), RadicalInverse_VdC(i));
   }
 
-  t_vec3 ImportanceSampleGGX(t_vec2 Xi, float roughness, t_vec3 N) {
+  t_vec3 ImportanceSampleGGX(t_vec2 Xi, fp_type roughness, t_vec3 N) {
     fp_type a = roughness * roughness;
 
     fp_type phi = 2.0 * M_PI * Xi.x;
@@ -341,7 +341,7 @@ struct PBRShaderCPU {
     return normalize(sampleVec);
   }
 
-  float GeometrySchlickGGX(fp_type NdotV, fp_type roughness) {
+  fp_type GeometrySchlickGGX(fp_type NdotV, fp_type roughness) {
     fp_type a = roughness;
     fp_type k = (a * a) / 2.0;
 
@@ -351,7 +351,7 @@ struct PBRShaderCPU {
     return nom / denom;
   }
 
-  float GeometrySmith(fp_type roughness, fp_type NoV, fp_type NoL) {
+  fp_type GeometrySmith(fp_type roughness, fp_type NoV, fp_type NoL) {
     fp_type ggx2 = GeometrySchlickGGX(NoV, roughness);
     fp_type ggx1 = GeometrySchlickGGX(NoL, roughness);
 
@@ -401,8 +401,8 @@ struct PBRShaderCPU {
 
   t_vec3 getIBLContribution(PBRInfo<fp_type> pbrInputs, t_vec3 n,
                             t_vec3 reflection) {
-    float mipCount = 9.0f;  // resolution of 512x512
-    float lod = pbrInputs.perceptualRoughness * mipCount;
+    fp_type mipCount = 9.0f;  // resolution of 512x512
+    fp_type lod = pbrInputs.perceptualRoughness * mipCount;
     // retrieve a scale and bias to F0. See [1], Figure 3
     t_vec2 brdf;
 
@@ -625,7 +625,7 @@ struct PBRShaderCPU {
   // https://archive.org/details/lambertsphotome00lambgoog See also [1],
   // Equation 1
   // t_vec3 diffuse(PBRInfo pbrInputs) {
-  //  return {pbrInputs.diffuseColor / float(M_PI)};
+  //  return {pbrInputs.diffuseColor / fp_type(M_PI)};
   //}
 
   // use Disney's equation for diffuse
@@ -701,7 +701,7 @@ struct PBRShaderCPU {
 
   bool useNormalMap = false;
   sampler2D<fp_type> u_NormalSampler;
-  float u_NormalScale = 1;
+  fp_type u_NormalScale = 1;
 
   bool useEmissiveMap = false;
   sampler2D<fp_type> u_EmissiveSampler;
@@ -712,7 +712,7 @@ struct PBRShaderCPU {
 
   bool useOcclusionMap = false;
   sampler2D<fp_type> u_OcclusionSampler;
-  float u_OcclusionStrength = 1;
+  fp_type u_OcclusionStrength = 1;
 
   t_vec2 u_MetallicRoughnessValues = {1, 1};
   t_vec4 u_BaseColorFactor;

--- a/examples/pbr_surface/pbr_maths.hh
+++ b/examples/pbr_surface/pbr_maths.hh
@@ -1,9 +1,14 @@
 #pragma once
-
 #include <chrono>
 #include <glm.hpp>
 
 #define HAS_NORMALS
+
+#define ADD_TEMPLATED_TYPES(fp_type) \
+    using t_vec2 = glm::vec<2, fp_type, glm::precision::highp>;\
+    using t_vec3 = glm::vec<3, fp_type, glm::precision::highp>;\
+    using t_vec4 = glm::vec<4, fp_type, glm::precision::highp>;\
+
 
 // This is inspired by the sample implementation from khronos found here :
 // https://github.com/KhronosGroup/glTF-WebGL-PBR/blob/master/shaders/pbr-frag.glsl
@@ -13,17 +18,17 @@
 namespace pbr_maths {
 
 // Compile time constants
-constexpr static float const c_MinRoughness = 0.04f;
+constexpr static double const c_MinRoughness = 0.04;
 #ifndef M_PI
-constexpr static float const M_PI = 3.141592653589793f;
+constexpr static double const M_PI = 3.141592653589793;
 #endif
 
 // GLSL data types
 using glm::mat3;
 using glm::mat4;
-using glm::vec2;
-using glm::vec3;
-using glm::vec4;
+//using glm::t_vec2;
+//using glm::vec3;
+//using glm::t_vec4;
 
 // GLSL functions
 using glm::clamp;
@@ -35,8 +40,13 @@ using glm::mix;
 using glm::normalize;
 using glm::step;
 
+
 /// GLSL sampler2D object
+template <typename fp_type>
 struct sampler2D {
+
+  ADD_TEMPLATED_TYPES(fp_type);
+
   enum class outOfBounds { clamp, wrap };
   outOfBounds boundsOperation;
 
@@ -47,10 +57,10 @@ struct sampler2D {
 
     /// Return a number between 0 and 1 that correspond to the byte vale
     /// between 0 to 255
-    static float to_float(uint8_t v) { return float(v) / 255.f; }
+    static fp_type to_float(uint8_t v) { return fp_type(v) / 255.f; }
 
-    /// Convert this object to a glm::vec4 (like a color in GLSL) implicitly
-    operator vec4() const {
+    /// Convert this object to a glm::t_vec4 (like a color in GLSL) implicitly
+    operator t_vec4() const {
       return {to_float(r), to_float(g), to_float(b), to_float(a)};
     }
   };
@@ -68,9 +78,9 @@ struct sampler2D {
     return getPixel(std::get<0>(coord), std::get<1>(coord));
   }
 
-  std::tuple<size_t, size_t> getPixelUV(const vec2& uv) const {
+  std::tuple<size_t, size_t> getPixelUV(const t_vec2& uv) const {
     // wrap uvs
-    vec2 buv;
+    t_vec2 buv;
 
     auto in_bound = [=](float a) {
       switch (boundsOperation) {
@@ -98,7 +108,7 @@ struct sampler2D {
     return std::make_tuple(px_x, px_y);
   }
 
-  pixel getPixel(const vec2& uv) const { return getPixel(getPixelUV(uv)); }
+  pixel getPixel(const t_vec2& uv) const { return getPixel(getPixelUV(uv)); }
 
   /// Activate texture filtering
   mutable bool linearFiltering = false;
@@ -111,48 +121,57 @@ struct sampler2D {
 };
 
 /// Simple linear interpolation on floats
-float lerp(float a, float b, float f) { return a + f * (b - a); }
+template <typename fp_type>
+fp_type lerp(fp_type a, fp_type b, fp_type f) {
+  return a + f * (b - a);
+}
 
 /// Replicate the texture2D function from GLSL
-vec4 texture2D(const sampler2D& sampler, const vec2& uv) {
+template <typename fp_type, typename uv_vec>
+auto texture2D(const sampler2D<fp_type>& sampler, const uv_vec& uv) {
+  ADD_TEMPLATED_TYPES(fp_type)
   auto pixelUV = sampler.getPixelUV(uv);
   auto px_x = std::get<0>(pixelUV);
   auto px_y = std::get<1>(pixelUV);
 
   // TODO linear interpolation on pixel values
   if (sampler.linearFiltering) {
-    const auto textureSize = vec2(sampler.width, sampler.height);
-    const auto texelSize = vec2(1.0f / textureSize.x, 1.0f / textureSize.y);
+    const auto textureSize = t_vec2(sampler.width, sampler.height);
+    const auto texelSize = t_vec2(1.0f / textureSize.x, 1.0f / textureSize.y);
 
-    vec4 tl = sampler.getPixel(uv);
-    vec4 tr = sampler.getPixel(uv + vec2(texelSize.x, 0));
-    vec4 bl = sampler.getPixel(uv + vec2(0, texelSize.y));
-    vec4 br = sampler.getPixel(uv + texelSize);
+    t_vec4 tl = sampler.getPixel(uv);
+    t_vec4 tr = sampler.getPixel(uv + t_vec2(texelSize.x, 0));
+    t_vec4 bl = sampler.getPixel(uv + t_vec2(0, texelSize.y));
+    t_vec4 br = sampler.getPixel(uv + texelSize);
 
-    vec2 f = fract(uv * textureSize);
-    vec4 tA = mix(tl, tr, f.x);
-    vec4 tB = mix(bl, br, f.x);
-    return mix(tA, tB, f.y);
+    t_vec2 f = fract(uv * textureSize);
+    t_vec4 tA = mix(tl, tr, f.x);
+    t_vec4 tB = mix(bl, br, f.x);
+    return t_vec4(mix(tA, tB, f.y));
   }
 
   // return the selected pixel
-  return sampler.pixels[px_y * sampler.width + px_x];
+  return t_vec4(sampler.pixels[px_y * sampler.width + px_x]);
 }
 
 /// Cubemap sampler object
+template <typename fp_type>
 struct samplerCube {
   /// Indexes for the faces of the cubemap
   enum cubemap_faces : size_t { LEFT, RIGHT, UP, DOWN, FRONT, BACK };
-  sampler2D& getFace(cubemap_faces f) { return faces[f]; }
-  sampler2D faces[6];
+  sampler2D<fp_type>& getFace(cubemap_faces f) { return faces[f]; }
+  sampler2D<fp_type> faces[6];
 
   void releasePixels() {
     for (auto& face : faces) face.releasePixels();
   }
 };
 
-void convert_xyz_to_cube_uv(float x, float y, float z, int* index, float* u,
-                            float* v) {
+/// Get the cooresponding UV and face index of a cubemap from a ray/normal
+/// vector
+template <typename fp_type>
+void convert_xyz_to_cube_uv(fp_type x, fp_type y, fp_type z, int* index,
+                            fp_type* u, fp_type* v) {
   float absX = fabs(x);
   float absY = fabs(y);
   float absZ = fabs(z);
@@ -223,9 +242,10 @@ void convert_xyz_to_cube_uv(float x, float y, float z, int* index, float* u,
   *v = 0.5f * (vc / maxAxis + 1.0f);
 }
 
-vec4 textureCube(const samplerCube& sampler, vec3 direction) {
+template <typename fp_type>
+auto textureCube(const samplerCube<fp_type>& sampler, glm::vec<3, fp_type, glm::precision::highp> direction) {
   int i;
-  vec2 uv;
+  t_vec2 uv;
   normalize(direction);
   convert_xyz_to_cube_uv(direction.x, direction.y, direction.z, &i, &uv.s,
                          &uv.t);
@@ -234,21 +254,23 @@ vec4 textureCube(const samplerCube& sampler, vec3 direction) {
 }
 
 // This data-structure is used throughout the code here
+template <typename fp_type>
 struct PBRInfo {
-  float NdotL;  // cos angle between normal and light direction
-  float NdotV;  // cos angle between normal and view direction
-  float NdotH;  // cos angle between normal and half vector
-  float LdotH;  // cos angle between light direction and half vector
-  float VdotH;  // cos angle between view direction and half vector
-  float perceptualRoughness;  // roughness value, as authored by the model
-                              // creator (input to shader)
-  float metalness;            // metallic value at the surface
-  vec3 reflectance0;          // full reflectance color (normal incidence angle)
-  vec3 reflectance90;         // reflectance color at grazing angle
-  float alphaRoughness;       // roughness mapped to a more linear change in the
-                              // roughness (proposed by [2])
-  vec3 diffuseColor;          // color contribution from diffuse lighting
-  vec3 specularColor;         // color contribution from specular lighting
+  ADD_TEMPLATED_TYPES(fp_type);
+  fp_type NdotL;  // cos angle between normal and light direction
+  fp_type NdotV;  // cos angle between normal and view direction
+  fp_type NdotH;  // cos angle between normal and half vector
+  fp_type LdotH;  // cos angle between light direction and half vector
+  fp_type VdotH;  // cos angle between view direction and half vector
+  fp_type perceptualRoughness;  // roughness value, as authored by the model
+                                // creator (input to shader)
+  fp_type metalness;            // metallic value at the surface
+  t_vec3 reflectance0;       // full reflectance color (normal incidence angle)
+  t_vec3 reflectance90;      // reflectance color at grazing angle
+  fp_type alphaRoughness;  // roughness mapped to a more linear change in the
+                           // roughness (proposed by [2])
+  t_vec3 diffuseColor;       // color contribution from diffuse lighting
+  t_vec3 specularColor;      // color contribution from specular lighting
 };
 
 #define MANUAL_SRGB ;
@@ -256,23 +278,27 @@ struct PBRInfo {
 /// Object that represent the fragment shader, and all of it's global state, but
 /// in C++. The intended use is that you set all the parameters that *should* be
 /// global for the shader and set by OpenGL call when using the program
+template <typename fp_type>
 struct PBRShaderCPU {
+
+  ADD_TEMPLATED_TYPES(fp_type);
+
   /// Virtual output : color of the "fragment" (aka: the pixel here)
-  vec4 gl_FragColor;
+  t_vec4 gl_FragColor;
 
   // TODO This is just a pass-through function. This will depend on the color
   // space used on the fed textures...
-  vec4 SRGBtoLINEAR(vec4 srgbIn) {
+  t_vec4 SRGBtoLINEAR(t_vec4 srgbIn) {
 #ifdef MANUAL_SRGB
 #ifdef SRGB_FAST_APPROXIMATION
-    vec3 linOut = pow(srgbIn.xyz, vec3(2.2));
+    t_vec3 linOut = pow(srgbIn.xyz, t_vec3(2.2));
 #else   // SRGB_FAST_APPROXIMATION
-    vec3 bLess = step(vec3(0.04045f), vec3(srgbIn));
-    vec3 linOut = mix(
-        vec3(srgbIn) / vec3(12.92f),
-        pow((vec3(srgbIn) + vec3(0.055f)) / vec3(1.055f), vec3(2.4f)), bLess);
+    t_vec3 bLess = step(t_vec3(0.04045), t_vec3(srgbIn));
+    t_vec3 linOut = mix(
+        t_vec3(srgbIn) / t_vec3(12.92),
+        pow((t_vec3(srgbIn) + t_vec3(0.055)) / t_vec3(1.055), t_vec3(2.4)), bLess);
 #endif  // SRGB_FAST_APPROXIMATION
-    return vec4(linOut, srgbIn.w);
+    return t_vec4(linOut, srgbIn.w);
     ;
 #else   // MANUAL_SRGB
     return srgbIn;
@@ -282,92 +308,91 @@ struct PBRShaderCPU {
   // Code from "Image Based Lighting" section of the Unreal PBR article. Based
   // on the C++ re-implementation of the integration code from
   // https://github.com/HectorMF/BRDFGenerator (MIT)
-
-  float RadicalInverse_VdC(unsigned int bits) {
+  fp_type RadicalInverse_VdC(unsigned int bits) {
     bits = (bits << 16u) | (bits >> 16u);
     bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
     bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
     bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
     bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
-    return float(bits) * 2.3283064365386963e-10;
+    return fp_type(bits) * 2.3283064365386963e-10;
   }
 
-  vec2 Hammersley(unsigned int i, unsigned int N) {
-    return vec2(float(i) / float(N), RadicalInverse_VdC(i));
+  t_vec2 Hammersley(unsigned int i, unsigned int N) {
+    return t_vec2(fp_type(i) / fp_type(N), RadicalInverse_VdC(i));
   }
 
-  vec3 ImportanceSampleGGX(vec2 Xi, float roughness, vec3 N) {
-    float a = roughness * roughness;
+  t_vec3 ImportanceSampleGGX(t_vec2 Xi, float roughness, t_vec3 N) {
+    fp_type a = roughness * roughness;
 
-    float phi = 2.0 * M_PI * Xi.x;
-    float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
-    float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+    fp_type phi = 2.0 * M_PI * Xi.x;
+    fp_type cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+    fp_type sinTheta = sqrt(1.0 - cosTheta * cosTheta);
 
     // from spherical coordinates to cartesian coordinates
-    vec3 H;
+    t_vec3 H;
     H.x = cos(phi) * sinTheta;
     H.y = sin(phi) * sinTheta;
     H.z = cosTheta;
 
     // from tangent-space vector to world-space sample vector
-    vec3 up = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
-    vec3 tangent = normalize(cross(up, N));
-    vec3 bitangent = cross(N, tangent);
+    t_vec3 up = abs(N.z) < 0.999 ? t_vec3(0.0, 0.0, 1.0) : t_vec3(1.0, 0.0, 0.0);
+    t_vec3 tangent = normalize(cross(up, N));
+    t_vec3 bitangent = cross(N, tangent);
 
-    vec3 sampleVec = tangent * H.x + bitangent * H.y + N * H.z;
+    t_vec3 sampleVec = tangent * H.x + bitangent * H.y + N * H.z;
     return normalize(sampleVec);
   }
 
-  float GeometrySchlickGGX(float NdotV, float roughness) {
-    float a = roughness;
-    float k = (a * a) / 2.0;
+  float GeometrySchlickGGX(fp_type NdotV, fp_type roughness) {
+    fp_type a = roughness;
+    fp_type k = (a * a) / 2.0;
 
-    float nom = NdotV;
-    float denom = NdotV * (1.0 - k) + k;
+    fp_type nom = NdotV;
+    fp_type denom = NdotV * (1.0 - k) + k;
 
     return nom / denom;
   }
 
-  float GeometrySmith(float roughness, float NoV, float NoL) {
-    float ggx2 = GeometrySchlickGGX(NoV, roughness);
-    float ggx1 = GeometrySchlickGGX(NoL, roughness);
+  float GeometrySmith(fp_type roughness, fp_type NoV, fp_type NoL) {
+    fp_type ggx2 = GeometrySchlickGGX(NoV, roughness);
+    fp_type ggx1 = GeometrySchlickGGX(NoL, roughness);
 
     return ggx1 * ggx2;
   }
 
-  vec2 IntegrateBRDF(float NdotV, float roughness, unsigned int samples) {
-    vec3 V;
+  t_vec2 IntegrateBRDF(fp_type NdotV, fp_type roughness, unsigned int samples) {
+    t_vec3 V;
     V.x = sqrt(1.0 - NdotV * NdotV);
     V.y = 0.0;
     V.z = NdotV;
 
-    float A = 0.0;
-    float B = 0.0;
+    fp_type A = 0.0;
+    fp_type B = 0.0;
 
-    vec3 N = vec3(0.0, 0.0, 1.0);
+    t_vec3 N = t_vec3(0.0, 0.0, 1.0);
 
     for (unsigned int i = 0u; i < samples; ++i) {
-      vec2 Xi = Hammersley(i, samples);
-      vec3 H = ImportanceSampleGGX(Xi, roughness, N);
-      vec3 L = normalize(2.0f * dot(V, H) * H - V);
+      t_vec2 Xi = Hammersley(i, samples);
+      t_vec3 H = ImportanceSampleGGX(Xi, roughness, N);
+      t_vec3 L = normalize(2.0f * dot(V, H) * H - V);
 
-      float NoL = max(L.z, 0.0f);
-      float NoH = max(H.z, 0.0f);
-      float VoH = max(dot(V, H), 0.0f);
-      float NoV = max(dot(N, V), 0.0f);
+      fp_type NoL = max(L.z, fp_type(0.0));
+      fp_type NoH = max(H.z, fp_type(0.0));
+      fp_type VoH = max(dot(V, H), fp_type(0.0));
+      fp_type NoV = max(dot(N, V), fp_type(0.0));
 
       if (NoL > 0.0) {
-        float G = GeometrySmith(roughness, NoV, NoL);
+        fp_type G = GeometrySmith(roughness, NoV, NoL);
 
-        float G_Vis = (G * VoH) / (NoH * NoV);
-        float Fc = pow(1.0 - VoH, 5.0);
+        fp_type G_Vis = (G * VoH) / (NoH * NoV);
+        fp_type Fc = pow(1.0 - VoH, 5.0);
 
         A += (1.0 - Fc) * G_Vis;
         B += Fc * G_Vis;
       }
     }
 
-    return vec2(A / float(samples), B / float(samples));
+    return t_vec2(A / fp_type(samples), B / fp_type(samples));
   }
 
   // Calculation of the lighting contribution from an optional Image Based Light
@@ -375,39 +400,40 @@ struct PBRShaderCPU {
   // Precomputed Environment Maps are required uniform inputs and are computed
   // as outlined in [1]. See our README.md on Environment Maps [3] for
   // additional discussion.
-  vec3 getIBLContribution(PBRInfo pbrInputs, vec3 n, vec3 reflection) {
+
+  t_vec3 getIBLContribution(PBRInfo<fp_type> pbrInputs, t_vec3 n, t_vec3 reflection) {
     float mipCount = 9.0f;  // resolution of 512x512
     float lod = pbrInputs.perceptualRoughness * mipCount;
     // retrieve a scale and bias to F0. See [1], Figure 3
-    vec2 brdf;
+    t_vec2 brdf;
 
     if (use_ILB_BRDF_LUT) {
-      auto brdf3 = vec3(SRGBtoLINEAR(texture2D(
+      auto brdf3 = t_vec3(SRGBtoLINEAR(texture2D(
           u_brdfLUT,
-          vec2(pbrInputs.NdotV, 1.0f - pbrInputs.perceptualRoughness))));
+          t_vec2(pbrInputs.NdotV, 1.0 - pbrInputs.perceptualRoughness))));
 
       // Only use RG channel
       brdf.x = brdf3.x;
       brdf.y = brdf3.y;
     } else {
-      brdf = vec2(IntegrateBRDF(pbrInputs.NdotV,
-                                1.0f - pbrInputs.perceptualRoughness,
+      brdf = t_vec2(IntegrateBRDF(pbrInputs.NdotV,
+                                1.0 - pbrInputs.perceptualRoughness,
                                 brdfResolution));
     }
 
-    vec3 diffuseLight = vec3(SRGBtoLINEAR(textureCube(u_DiffuseEnvSampler, n)));
+    t_vec3 diffuseLight = t_vec3(SRGBtoLINEAR(textureCube(u_DiffuseEnvSampler, n)));
 
 #ifdef USE_TEX_LOD
-    vec3 specularLight =
+    t_vec3 specularLight =
         SRGBtoLINEAR(textureCubeLodEXT(u_SpecularEnvSampler, reflection, lod))
             .rgb;
 #else
-    vec3 specularLight =
-        vec3(SRGBtoLINEAR(textureCube(u_SpecularEnvSampler, reflection)));
+    t_vec3 specularLight =
+        t_vec3(SRGBtoLINEAR(textureCube(u_SpecularEnvSampler, reflection)));
 #endif
 
-    vec3 diffuse = diffuseLight * pbrInputs.diffuseColor;
-    vec3 specular = specularLight * (pbrInputs.specularColor * brdf.x + brdf.y);
+    t_vec3 diffuse = diffuseLight * pbrInputs.diffuseColor;
+    t_vec3 specular = specularLight * (pbrInputs.specularColor * brdf.x + brdf.y);
 
     // For presentation, this allows us to disable IBL terms
     diffuse *= u_ScaleIBLAmbient.x;
@@ -420,14 +446,14 @@ struct PBRShaderCPU {
     // Metallic and Roughness material properties are packed together
     // In glTF, these factors can be specified by fixed scalar values
     // or from a metallic-roughness map
-    float perceptualRoughness = u_MetallicRoughnessValues.y;
-    float metallic = u_MetallicRoughnessValues.x;
+    fp_type perceptualRoughness = u_MetallicRoughnessValues.y;
+    fp_type metallic = u_MetallicRoughnessValues.x;
 
     if (useMetalRoughMap) {
       // Roughness is stored in the 'g' channel, metallic is stored in the 'b'
       // channel. This layout intentionally reserves the 'r' channel for
       // (optional) occlusion map data
-      vec4 mrSample = texture2D(u_MetallicRoughnessSampler, v_UV);
+      t_vec4 mrSample = texture2D(u_MetallicRoughnessSampler, v_UV);
 
       // NOTE: G channel of the map is used for roughness, B channel is used for
       // metalness
@@ -435,14 +461,14 @@ struct PBRShaderCPU {
       metallic = mrSample.b * metallic;
     }
 
-    perceptualRoughness = clamp(perceptualRoughness, c_MinRoughness, 1.0f);
-    metallic = clamp(metallic, 0.0f, 1.0f);
+    perceptualRoughness = clamp(perceptualRoughness, fp_type(c_MinRoughness), fp_type(1.0));
+    metallic = clamp(metallic, fp_type(0.0), fp_type(1.0));
     // Roughness is authored as perceptual roughness; as is convention,
     // convert to material roughness by squaring the perceptual roughness [2].
-    float alphaRoughness = perceptualRoughness * perceptualRoughness;
+    fp_type alphaRoughness = perceptualRoughness * perceptualRoughness;
 
     // The albedo may be defined from a base texture or a flat color
-    vec4 baseColor;
+    t_vec4 baseColor;
     if (useBaseColorMap) {
       baseColor =
           SRGBtoLINEAR(texture2D(u_BaseColorSampler, v_UV)) * u_BaseColorFactor;
@@ -450,61 +476,61 @@ struct PBRShaderCPU {
       baseColor = u_BaseColorFactor;
     }
 
-    vec3 f0 = vec3(0.04f);
-    vec3 diffuseColor = vec3(baseColor) * (vec3(1.0f) - f0);
+    t_vec3 f0 = t_vec3(0.04f);
+    t_vec3 diffuseColor = t_vec3(baseColor) * (t_vec3(1.0f) - f0);
     diffuseColor *= 1.0 - metallic;
-    vec3 specularColor = mix(f0, vec3(baseColor), metallic);
+    t_vec3 specularColor = mix(f0, t_vec3(baseColor), metallic);
 
     // Compute reflectance.
-    float reflectance =
+    fp_type reflectance =
         max(max(specularColor.r, specularColor.g), specularColor.b);
 
     // For typical incident reflectance range (between 4% to 100%) set the
     // grazing reflectance to 100% for typical fresnel effect. For very low
     // reflectance range on highly diffuse objects (below 4%), incrementally
     // reduce grazing reflectance to 0%.
-    float reflectance90 = clamp(reflectance * 25.0f, 0.0f, 1.0f);
-    vec3 specularEnvironmentR0 = specularColor;
-    vec3 specularEnvironmentR90 = vec3(1.0f, 1.0f, 1.0f) * reflectance90;
+    fp_type reflectance90 = clamp(reflectance * fp_type(25.0), fp_type(0.0), fp_type(1.0));
+    t_vec3 specularEnvironmentR0 = specularColor;
+    t_vec3 specularEnvironmentR90 = t_vec3(fp_type(1), fp_type(1), fp_type(1)) * reflectance90;
 
-    vec3 n = getNormal();  // normal at surface point
-    vec3 v = normalize(u_Camera -
+    t_vec3 n = getNormal();  // normal at surface point
+    t_vec3 v = normalize(u_Camera -
                        v_Position);  // Vector from surface point to camera
-    vec3 l = normalize(u_LightDirection);  // Vector from surface point to light
-    vec3 h = normalize(l + v);             // Half vector between both l and v
-    vec3 reflection = -normalize(reflect(v, n));
+    t_vec3 l = normalize(u_LightDirection);  // Vector from surface point to light
+    t_vec3 h = normalize(l + v);             // Half vector between both l and v
+    t_vec3 reflection = -normalize(reflect(v, n));
 
-    float NdotL = clamp(dot(n, l), 0.001f, 1.0f);
-    float NdotV = clamp(std::abs(dot(n, v)), 0.001f, 1.0f);
-    float NdotH = clamp(dot(n, h), 0.0f, 1.0f);
-    float LdotH = clamp(dot(l, h), 0.0f, 1.0f);
-    float VdotH = clamp(dot(v, h), 0.0f, 1.0f);
+    fp_type NdotL = clamp(dot(n, l), 0.001f, 1.0f);
+    fp_type NdotV = clamp(std::abs(dot(n, v)), 0.001f, 1.0f);
+    fp_type NdotH = clamp(dot(n, h), 0.0f, 1.0f);
+    fp_type LdotH = clamp(dot(l, h), 0.0f, 1.0f);
+    fp_type VdotH = clamp(dot(v, h), 0.0f, 1.0f);
 
     // Hey, modern C++ uniform initialization syntax just works!
-    PBRInfo pbrInputs = PBRInfo{NdotL,
-                                NdotV,
-                                NdotH,
-                                LdotH,
-                                VdotH,
-                                perceptualRoughness,
-                                metallic,
-                                specularEnvironmentR0,
-                                specularEnvironmentR90,
-                                alphaRoughness,
-                                diffuseColor,
-                                specularColor};
+    PBRInfo<fp_type> pbrInputs = PBRInfo<fp_type>{NdotL,
+                                                  NdotV,
+                                                  NdotH,
+                                                  LdotH,
+                                                  VdotH,
+                                                  perceptualRoughness,
+                                                  metallic,
+                                                  specularEnvironmentR0,
+                                                  specularEnvironmentR90,
+                                                  alphaRoughness,
+                                                  diffuseColor,
+                                                  specularColor};
 
     // Calculate the shading terms for the microfacet specular shading model
-    vec3 F = specularReflection(pbrInputs);
-    float G = geometricOcclusion(pbrInputs);
-    float D = microfacetDistribution(pbrInputs);
+    t_vec3 F = specularReflection(pbrInputs);
+    fp_type G = geometricOcclusion(pbrInputs);
+    fp_type D = microfacetDistribution(pbrInputs);
 
     // Calculation of analytical lighting contribution
-    vec3 diffuseContrib = (1.0f - F) * diffuse(pbrInputs);
-    vec3 specContrib = F * G * D / (4.0f * NdotL * NdotV);
+    t_vec3 diffuseContrib = (fp_type(1.0) - F) * diffuse(pbrInputs);
+    t_vec3 specContrib = F * G * D / (fp_type(4.0) * NdotL * NdotV);
     // Obtain final intensity as reflectance (BRDF) scaled by the energy of the
     // light (cosine law)
-    vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
+    t_vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
 
     // Calculate lighting contribution from image based lighting source (IBL)
 
@@ -515,55 +541,55 @@ struct PBRShaderCPU {
     // Apply optional PBR terms for additional (optional) shading
 
     if (useOcclusionMap) {
-      float ao = texture2D(u_OcclusionSampler, v_UV).r;
+      fp_type ao = texture2D(u_OcclusionSampler, v_UV).r;
       color = mix(color, color * ao, u_OcclusionStrength);
     }
 
     if (useEmissiveMap) {
-      vec3 emissive = SRGBtoLINEAR(
-          vec4(vec3(texture2D(u_EmissiveSampler, v_UV)) * u_EmissiveFactor, 1));
+      t_vec3 emissive = SRGBtoLINEAR(
+          t_vec4(t_vec3(texture2D(u_EmissiveSampler, v_UV)) * u_EmissiveFactor, 1));
       color += emissive;
     }
 
     // This section uses mix to override final color for reference app
     // visualization of various parameters in the lighting equation.
     color = mix(color, F, u_ScaleFGDSpec.x);
-    color = mix(color, vec3(G), u_ScaleFGDSpec.y);
-    color = mix(color, vec3(D), u_ScaleFGDSpec.z);
+    color = mix(color, t_vec3(G), u_ScaleFGDSpec.y);
+    color = mix(color, t_vec3(D), u_ScaleFGDSpec.z);
     color = mix(color, specContrib, u_ScaleFGDSpec.w);
 
     color = mix(color, diffuseContrib, u_ScaleDiffBaseMR.x);
-    color = mix(color, vec3(baseColor), u_ScaleDiffBaseMR.y);
-    color = mix(color, vec3(metallic), u_ScaleDiffBaseMR.z);
-    color = mix(color, vec3(perceptualRoughness), u_ScaleDiffBaseMR.w);
+    color = mix(color, t_vec3(baseColor), u_ScaleDiffBaseMR.y);
+    color = mix(color, t_vec3(metallic), u_ScaleDiffBaseMR.z);
+    color = mix(color, t_vec3(perceptualRoughness), u_ScaleDiffBaseMR.w);
 
-    gl_FragColor = vec4(pow(color, vec3(1.0f / 2.2f)), baseColor.a);
+    gl_FragColor = t_vec4(pow(color, t_vec3(1.0f / 2.2f)), baseColor.a);
   }
 
   // Find the normal for this fragment, pulling either from a predefined normal
   // map
   // or from the interpolated mesh normal and tangent attributes.
-  vec3 getNormal() {
+  t_vec3 getNormal() {
     // Retrieve the tangent space matrix
 #ifndef HAS_TANGENTS
-    /*    vec3 pos_dx = dFdx(v_Position);
-    vec3 pos_dy = dFdy(v_Position);
-    vec3 tex_dx = dFdx(vec3(v_UV, 0.0));
-    vec3 tex_dy = dFdy(vec3(v_UV, 0.0));
-    vec3 t = (tex_dy.t * pos_dx - tex_dx.t * pos_dy) /
+    /*    t_vec3 pos_dx = dFdx(v_Position);
+    t_vec3 pos_dy = dFdy(v_Position);
+    t_vec3 tex_dx = dFdx(t_vec3(v_UV, 0.0));
+    t_vec3 tex_dy = dFdy(t_vec3(v_UV, 0.0));
+    t_vec3 t = (tex_dy.t * pos_dx - tex_dx.t * pos_dy) /
              (tex_dx.s * tex_dy.t - tex_dy.s * tex_dx.t)*/
     ;
 #ifdef HAS_NORMALS
-    vec3 ng = normalize(v_Normal);
+    t_vec3 ng = normalize(v_Normal);
 #else
-    vec3 ng = cross(pos_dx, pos_dy);
+    t_vec3 ng = cross(pos_dx, pos_dy);
 #endif
 
     // This is some random hack to calculate "a" tangent vector
-    vec3 t;
+    t_vec3 t;
 
-    vec3 c1 = cross(ng, vec3(0.0f, 0.0f, 1.0f));
-    vec3 c2 = cross(ng, vec3(0.0f, 1.0f, 0.0f));
+    t_vec3 c1 = cross(ng, t_vec3(0.0f, 0.0f, 1.0f));
+    t_vec3 c2 = cross(ng, t_vec3(0.0f, 1.0f, 0.0f));
 
     if (length(c1) > length(c2)) {
       t = c1;
@@ -572,16 +598,16 @@ struct PBRShaderCPU {
     }
 
     t = normalize(t - ng * dot(ng, t));
-    vec3 b = normalize(cross(ng, t));
+    t_vec3 b = normalize(cross(ng, t));
     mat3 tbn = mat3(t, b, ng);
 #else  // HAS_TANGENTS
     mat3 tbn = v_TBN;
 #endif
-    vec3 n;
+    t_vec3 n;
     if (useNormalMap) {
-      n = vec3(texture2D(u_NormalSampler, v_UV));
+      n = t_vec3(texture2D(u_NormalSampler, v_UV));
       n = normalize(
-          tbn * ((2.0f * n - 1.0f) * vec3(u_NormalScale, u_NormalScale, 1.0)));
+          tbn * ((2.0f * n - 1.0f) * t_vec3(u_NormalScale, u_NormalScale, 1.0)));
     } else {
       // The tbn matrix is linearly interpolated, so we need to re-normalize
       n = normalize(tbn[2]);
@@ -593,7 +619,7 @@ struct PBRShaderCPU {
   // Implementation from Lambert's Photometria
   // https://archive.org/details/lambertsphotome00lambgoog See also [1],
   // Equation 1
-  // vec3 diffuse(PBRInfo pbrInputs) {
+  // t_vec3 diffuse(PBRInfo pbrInputs) {
   //  return {pbrInputs.diffuseColor / float(M_PI)};
   //}
 
@@ -601,19 +627,19 @@ struct PBRShaderCPU {
   // https://blog.selfshadow.com/publications/s2012-shading-course/burley/s2012_pbs_disney_brdf_notes_v3.pdf
   // See section 5.3 (correct for too dark diffuse on the edges in comparison
   // with the above, commented-out function)
-  vec3 diffuse(PBRInfo pbrInputs) {
-    float f90 =
+  t_vec3 diffuse(PBRInfo<fp_type> pbrInputs) {
+    fp_type f90 =
         2.0f * pbrInputs.LdotH * pbrInputs.LdotH * pbrInputs.alphaRoughness -
         0.5f;
 
-    return (pbrInputs.diffuseColor / float(M_PI)) *
-           (1.0f + f90 * float(pow((1.0f - pbrInputs.NdotL), 5.0f))) *
-           (1.0f + f90 * float(pow((1.0f - pbrInputs.NdotV), 5.0f)));
+    return (pbrInputs.diffuseColor / fp_type(M_PI)) *
+           (1.0f + f90 * fp_type(pow((1.0f - pbrInputs.NdotL), 5.0f))) *
+           (1.0f + f90 * fp_type(pow((1.0f - pbrInputs.NdotV), 5.0f)));
   }
 
   // The following equation models the Fresnel reflectance term of the spec
   // equation (aka F()) Implementation of fresnel from [4], Equation 15
-  vec3 specularReflection(PBRInfo pbrInputs) {
+  t_vec3 specularReflection(PBRInfo<fp_type> pbrInputs) {
     return pbrInputs.reflectance0 +
            (pbrInputs.reflectance90 - pbrInputs.reflectance0) *
                std::pow(clamp(1.0f - pbrInputs.VdotH, 0.0f, 1.0f), 5.0f);
@@ -623,14 +649,14 @@ struct PBRShaderCPU {
   // where rougher material will reflect less light back to the viewer.
   // This implementation is based on [1] Equation 4, and we adopt their
   // modifications to alphaRoughness as input as originally proposed in [2].
-  float geometricOcclusion(PBRInfo pbrInputs) {
-    float NdotL = pbrInputs.NdotL;
-    float NdotV = pbrInputs.NdotV;
-    float r = pbrInputs.alphaRoughness;
+  fp_type geometricOcclusion(PBRInfo<fp_type> pbrInputs) {
+    fp_type NdotL = pbrInputs.NdotL;
+    fp_type NdotV = pbrInputs.NdotV;
+    fp_type r = pbrInputs.alphaRoughness;
 
-    float attenuationL =
+    fp_type attenuationL =
         2.0f * NdotL / (NdotL + sqrt(r * r + (1.0f - r * r) * (NdotL * NdotL)));
-    float attenuationV =
+    fp_type attenuationV =
         2.0f * NdotV / (NdotV + sqrt(r * r + (1.0f - r * r) * (NdotV * NdotV)));
     return attenuationL * attenuationV;
   }
@@ -641,65 +667,68 @@ struct PBRShaderCPU {
   // T. S. Trowbridge, and K. P. Reitz Follows the distribution function
   // recommended in the SIGGRAPH 2013 course notes from EPIC Games [1],
   // Equation 3.
-  float microfacetDistribution(PBRInfo pbrInputs) {
-    float roughnessSq = pbrInputs.alphaRoughness * pbrInputs.alphaRoughness;
-    float f =
+  fp_type microfacetDistribution(PBRInfo<fp_type> pbrInputs) {
+    fp_type roughnessSq = pbrInputs.alphaRoughness * pbrInputs.alphaRoughness;
+    fp_type f =
         (pbrInputs.NdotH * roughnessSq - pbrInputs.NdotH) * pbrInputs.NdotH +
         1.0f;
     return roughnessSq / (M_PI * f * f);
   }
 
   // Global state of the original shader enclosed into member variables
-  vec3 u_LightDirection;
-  vec3 u_LightColor;
+  t_vec3 u_LightDirection;
+  t_vec3 u_LightColor;
 
   bool useILB = false;
   bool use_ILB_BRDF_LUT = false;
   bool forceBRDFCompute = true;
   int brdfResolution = 256;
-  samplerCube u_DiffuseEnvSampler;
-  samplerCube u_SpecularEnvSampler;
-  sampler2D u_brdfLUT;
+  samplerCube<fp_type> u_DiffuseEnvSampler;
+  samplerCube<fp_type> u_SpecularEnvSampler;
+  sampler2D<fp_type> u_brdfLUT;
 
   bool useBaseColorMap = false;
-  sampler2D u_BaseColorSampler;
+  sampler2D<fp_type> u_BaseColorSampler;
 
   bool useNormalMap = false;
-  sampler2D u_NormalSampler;
+  sampler2D<fp_type> u_NormalSampler;
   float u_NormalScale = 1;
 
   bool useEmissiveMap = false;
-  sampler2D u_EmissiveSampler;
-  vec3 u_EmissiveFactor;
+  sampler2D<fp_type> u_EmissiveSampler;
+  t_vec3 u_EmissiveFactor;
 
   bool useMetalRoughMap = false;
-  sampler2D u_MetallicRoughnessSampler;
+  sampler2D<fp_type> u_MetallicRoughnessSampler;
 
   bool useOcclusionMap = false;
-  sampler2D u_OcclusionSampler;
+  sampler2D<fp_type> u_OcclusionSampler;
   float u_OcclusionStrength = 1;
 
-  vec2 u_MetallicRoughnessValues = {1, 1};
-  vec4 u_BaseColorFactor;
+  t_vec2 u_MetallicRoughnessValues = {1, 1};
+  t_vec4 u_BaseColorFactor;
 
-  vec3 u_Camera;
+  t_vec3 u_Camera;
 
   // debugging flags used for shader output of intermediate PBR variables
-  vec4 u_ScaleDiffBaseMR{0};
-  vec4 u_ScaleFGDSpec{0};
-  vec4 u_ScaleIBLAmbient{0};
+  t_vec4 u_ScaleDiffBaseMR{0};
+  t_vec4 u_ScaleFGDSpec{0};
+  t_vec4 u_ScaleIBLAmbient{0};
 
-  vec3 v_Position;
+  t_vec3 v_Position;
 
-  vec2 v_UV;
+  t_vec2 v_UV;
 
 #ifdef HAS_NORMALS
 #ifdef HAS_TANGENTS
   mat3 v_TBN;
 #else
-  vec3 v_Normal;
+  t_vec3 v_Normal;
 #endif
 #endif
 };
 
 }  // namespace pbr_maths
+
+
+#undef ADD_TEMPLATED_TYPES

--- a/examples/pbr_surface/pbr_maths.hh
+++ b/examples/pbr_surface/pbr_maths.hh
@@ -4,11 +4,10 @@
 
 #define HAS_NORMALS
 
-#define ADD_TEMPLATED_TYPES(fp_type) \
-    using t_vec2 = glm::vec<2, fp_type, glm::precision::highp>;\
-    using t_vec3 = glm::vec<3, fp_type, glm::precision::highp>;\
-    using t_vec4 = glm::vec<4, fp_type, glm::precision::highp>;\
-
+#define ADD_TEMPLATED_TYPES(fp_type)                          \
+  using t_vec2 = glm::vec<2, fp_type, glm::precision::highp>; \
+  using t_vec3 = glm::vec<3, fp_type, glm::precision::highp>; \
+  using t_vec4 = glm::vec<4, fp_type, glm::precision::highp>;
 
 // This is inspired by the sample implementation from khronos found here :
 // https://github.com/KhronosGroup/glTF-WebGL-PBR/blob/master/shaders/pbr-frag.glsl
@@ -26,9 +25,9 @@ constexpr static double const M_PI = 3.141592653589793;
 // GLSL data types
 using glm::mat3;
 using glm::mat4;
-//using glm::t_vec2;
-//using glm::vec3;
-//using glm::t_vec4;
+// using glm::t_vec2;
+// using glm::vec3;
+// using glm::t_vec4;
 
 // GLSL functions
 using glm::clamp;
@@ -40,11 +39,9 @@ using glm::mix;
 using glm::normalize;
 using glm::step;
 
-
 /// GLSL sampler2D object
 template <typename fp_type>
 struct sampler2D {
-
   ADD_TEMPLATED_TYPES(fp_type);
 
   enum class outOfBounds { clamp, wrap };
@@ -128,7 +125,8 @@ fp_type lerp(fp_type a, fp_type b, fp_type f) {
 
 /// Replicate the texture2D function from GLSL
 template <typename fp_type, typename uv_vec>
-auto texture2D(const sampler2D<fp_type>& sampler, const uv_vec& uv) {
+    glm::vec < 4,
+    fp_type, glm::precision::highp> texture2D(const sampler2D<fp_type>& sampler, const uv_vec& uv) {
   ADD_TEMPLATED_TYPES(fp_type)
   auto pixelUV = sampler.getPixelUV(uv);
   auto px_x = std::get<0>(pixelUV);
@@ -243,7 +241,9 @@ void convert_xyz_to_cube_uv(fp_type x, fp_type y, fp_type z, int* index,
 }
 
 template <typename fp_type>
-auto textureCube(const samplerCube<fp_type>& sampler, glm::vec<3, fp_type, glm::precision::highp> direction) {
+glm::vec<4, fp_type, glm::precision::highp> textureCube(const samplerCube<fp_type>& sampler,
+                 glm::vec<3, fp_type, glm::precision::highp> direction) {
+  ADD_TEMPLATED_TYPES(fp_type);
   int i;
   t_vec2 uv;
   normalize(direction);
@@ -265,12 +265,12 @@ struct PBRInfo {
   fp_type perceptualRoughness;  // roughness value, as authored by the model
                                 // creator (input to shader)
   fp_type metalness;            // metallic value at the surface
-  t_vec3 reflectance0;       // full reflectance color (normal incidence angle)
-  t_vec3 reflectance90;      // reflectance color at grazing angle
+  t_vec3 reflectance0;     // full reflectance color (normal incidence angle)
+  t_vec3 reflectance90;    // reflectance color at grazing angle
   fp_type alphaRoughness;  // roughness mapped to a more linear change in the
                            // roughness (proposed by [2])
-  t_vec3 diffuseColor;       // color contribution from diffuse lighting
-  t_vec3 specularColor;      // color contribution from specular lighting
+  t_vec3 diffuseColor;     // color contribution from diffuse lighting
+  t_vec3 specularColor;    // color contribution from specular lighting
 };
 
 #define MANUAL_SRGB ;
@@ -280,7 +280,6 @@ struct PBRInfo {
 /// global for the shader and set by OpenGL call when using the program
 template <typename fp_type>
 struct PBRShaderCPU {
-
   ADD_TEMPLATED_TYPES(fp_type);
 
   /// Virtual output : color of the "fragment" (aka: the pixel here)
@@ -294,9 +293,10 @@ struct PBRShaderCPU {
     t_vec3 linOut = pow(srgbIn.xyz, t_vec3(2.2));
 #else   // SRGB_FAST_APPROXIMATION
     t_vec3 bLess = step(t_vec3(0.04045), t_vec3(srgbIn));
-    t_vec3 linOut = mix(
-        t_vec3(srgbIn) / t_vec3(12.92),
-        pow((t_vec3(srgbIn) + t_vec3(0.055)) / t_vec3(1.055), t_vec3(2.4)), bLess);
+    t_vec3 linOut =
+        mix(t_vec3(srgbIn) / t_vec3(12.92),
+            pow((t_vec3(srgbIn) + t_vec3(0.055)) / t_vec3(1.055), t_vec3(2.4)),
+            bLess);
 #endif  // SRGB_FAST_APPROXIMATION
     return t_vec4(linOut, srgbIn.w);
     ;
@@ -335,7 +335,8 @@ struct PBRShaderCPU {
     H.z = cosTheta;
 
     // from tangent-space vector to world-space sample vector
-    t_vec3 up = abs(N.z) < 0.999 ? t_vec3(0.0, 0.0, 1.0) : t_vec3(1.0, 0.0, 0.0);
+    t_vec3 up =
+        abs(N.z) < 0.999 ? t_vec3(0.0, 0.0, 1.0) : t_vec3(1.0, 0.0, 0.0);
     t_vec3 tangent = normalize(cross(up, N));
     t_vec3 bitangent = cross(N, tangent);
 
@@ -401,7 +402,8 @@ struct PBRShaderCPU {
   // as outlined in [1]. See our README.md on Environment Maps [3] for
   // additional discussion.
 
-  t_vec3 getIBLContribution(PBRInfo<fp_type> pbrInputs, t_vec3 n, t_vec3 reflection) {
+  t_vec3 getIBLContribution(PBRInfo<fp_type> pbrInputs, t_vec3 n,
+                            t_vec3 reflection) {
     float mipCount = 9.0f;  // resolution of 512x512
     float lod = pbrInputs.perceptualRoughness * mipCount;
     // retrieve a scale and bias to F0. See [1], Figure 3
@@ -417,11 +419,12 @@ struct PBRShaderCPU {
       brdf.y = brdf3.y;
     } else {
       brdf = t_vec2(IntegrateBRDF(pbrInputs.NdotV,
-                                1.0 - pbrInputs.perceptualRoughness,
-                                brdfResolution));
+                                  1.0 - pbrInputs.perceptualRoughness,
+                                  brdfResolution));
     }
 
-    t_vec3 diffuseLight = t_vec3(SRGBtoLINEAR(textureCube(u_DiffuseEnvSampler, n)));
+    t_vec3 diffuseLight =
+        t_vec3(SRGBtoLINEAR(textureCube(u_DiffuseEnvSampler, n)));
 
 #ifdef USE_TEX_LOD
     t_vec3 specularLight =
@@ -433,7 +436,8 @@ struct PBRShaderCPU {
 #endif
 
     t_vec3 diffuse = diffuseLight * pbrInputs.diffuseColor;
-    t_vec3 specular = specularLight * (pbrInputs.specularColor * brdf.x + brdf.y);
+    t_vec3 specular =
+        specularLight * (pbrInputs.specularColor * brdf.x + brdf.y);
 
     // For presentation, this allows us to disable IBL terms
     diffuse *= u_ScaleIBLAmbient.x;
@@ -461,7 +465,8 @@ struct PBRShaderCPU {
       metallic = mrSample.b * metallic;
     }
 
-    perceptualRoughness = clamp(perceptualRoughness, fp_type(c_MinRoughness), fp_type(1.0));
+    perceptualRoughness =
+        clamp(perceptualRoughness, fp_type(c_MinRoughness), fp_type(1.0));
     metallic = clamp(metallic, fp_type(0.0), fp_type(1.0));
     // Roughness is authored as perceptual roughness; as is convention,
     // convert to material roughness by squaring the perceptual roughness [2].
@@ -489,15 +494,18 @@ struct PBRShaderCPU {
     // grazing reflectance to 100% for typical fresnel effect. For very low
     // reflectance range on highly diffuse objects (below 4%), incrementally
     // reduce grazing reflectance to 0%.
-    fp_type reflectance90 = clamp(reflectance * fp_type(25.0), fp_type(0.0), fp_type(1.0));
+    fp_type reflectance90 =
+        clamp(reflectance * fp_type(25.0), fp_type(0.0), fp_type(1.0));
     t_vec3 specularEnvironmentR0 = specularColor;
-    t_vec3 specularEnvironmentR90 = t_vec3(fp_type(1), fp_type(1), fp_type(1)) * reflectance90;
+    t_vec3 specularEnvironmentR90 =
+        t_vec3(fp_type(1), fp_type(1), fp_type(1)) * reflectance90;
 
     t_vec3 n = getNormal();  // normal at surface point
     t_vec3 v = normalize(u_Camera -
-                       v_Position);  // Vector from surface point to camera
-    t_vec3 l = normalize(u_LightDirection);  // Vector from surface point to light
-    t_vec3 h = normalize(l + v);             // Half vector between both l and v
+                         v_Position);  // Vector from surface point to camera
+    t_vec3 l =
+        normalize(u_LightDirection);  // Vector from surface point to light
+    t_vec3 h = normalize(l + v);      // Half vector between both l and v
     t_vec3 reflection = -normalize(reflect(v, n));
 
     fp_type NdotL = clamp(dot(n, l), 0.001f, 1.0f);
@@ -546,8 +554,8 @@ struct PBRShaderCPU {
     }
 
     if (useEmissiveMap) {
-      t_vec3 emissive = SRGBtoLINEAR(
-          t_vec4(t_vec3(texture2D(u_EmissiveSampler, v_UV)) * u_EmissiveFactor, 1));
+      t_vec3 emissive = SRGBtoLINEAR(t_vec4(
+          t_vec3(texture2D(u_EmissiveSampler, v_UV)) * u_EmissiveFactor, 1));
       color += emissive;
     }
 
@@ -606,8 +614,8 @@ struct PBRShaderCPU {
     t_vec3 n;
     if (useNormalMap) {
       n = t_vec3(texture2D(u_NormalSampler, v_UV));
-      n = normalize(
-          tbn * ((2.0f * n - 1.0f) * t_vec3(u_NormalScale, u_NormalScale, 1.0)));
+      n = normalize(tbn * ((2.0f * n - 1.0f) *
+                           t_vec3(u_NormalScale, u_NormalScale, 1.0)));
     } else {
       // The tbn matrix is linearly interpolated, so we need to re-normalize
       n = normalize(tbn[2]);
@@ -729,6 +737,5 @@ struct PBRShaderCPU {
 };
 
 }  // namespace pbr_maths
-
 
 #undef ADD_TEMPLATED_TYPES

--- a/examples/pbr_surface/pbr_maths.hh
+++ b/examples/pbr_surface/pbr_maths.hh
@@ -125,8 +125,8 @@ fp_type lerp(fp_type a, fp_type b, fp_type f) {
 
 /// Replicate the texture2D function from GLSL
 template <typename fp_type, typename uv_vec>
-    glm::vec < 4,
-    fp_type, glm::precision::highp> texture2D(const sampler2D<fp_type>& sampler, const uv_vec& uv) {
+glm::vec<4, fp_type, glm::precision::highp> texture2D(
+    const sampler2D<fp_type>& sampler, const uv_vec& uv) {
   ADD_TEMPLATED_TYPES(fp_type)
   auto pixelUV = sampler.getPixelUV(uv);
   auto px_x = std::get<0>(pixelUV);
@@ -241,8 +241,9 @@ void convert_xyz_to_cube_uv(fp_type x, fp_type y, fp_type z, int* index,
 }
 
 template <typename fp_type>
-glm::vec<4, fp_type, glm::precision::highp> textureCube(const samplerCube<fp_type>& sampler,
-                 glm::vec<3, fp_type, glm::precision::highp> direction) {
+glm::vec<4, fp_type, glm::precision::highp> textureCube(
+    const samplerCube<fp_type>& sampler,
+    glm::vec<3, fp_type, glm::precision::highp> direction) {
   ADD_TEMPLATED_TYPES(fp_type);
   int i;
   t_vec2 uv;


### PR DESCRIPTION
Hi,

With this patch, every bit of maths computed by the PBR shader is no longer restricted to `float` precision. 

Types and free functions used are using the type in the template to represent a floating point number, for added flexibility.