### PR TITLE
Potential issue in examples/common/imgui/imgui.cpp: Unchecked return from initialization function

### DIFF
--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -4401,7 +4401,7 @@ static void ImGui::UpdateManualResize(ImGuiWindow* window, const ImVec2& size_au
         ImRect resize_rect(corner, corner + grip.InnerDir * grip_hover_size);
         if (resize_rect.Min.x > resize_rect.Max.x) ImSwap(resize_rect.Min.x, resize_rect.Max.x);
         if (resize_rect.Min.y > resize_rect.Max.y) ImSwap(resize_rect.Min.y, resize_rect.Max.y);
-        bool hovered, held;
+        bool hovered = false, held = false;
         ButtonBehavior(resize_rect, window->GetID((void*)(intptr_t)resize_grip_n), &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_NoNavFocus);
         if (hovered || held)
             g.MouseCursor = (resize_grip_n & 1) ? ImGuiMouseCursor_ResizeNESW : ImGuiMouseCursor_ResizeNWSE;
@@ -4426,7 +4426,7 @@ static void ImGui::UpdateManualResize(ImGuiWindow* window, const ImVec2& size_au
     {
         const float BORDER_SIZE = 5.0f;          // FIXME: Only works _inside_ window because of HoveredWindow check.
         const float BORDER_APPEAR_TIMER = 0.05f; // Reduce visual noise
-        bool hovered, held;
+        bool hovered = false, held = false;
         ImRect border_rect = GetResizeBorderRect(window, border_n, grip_hover_size, BORDER_SIZE);
         ButtonBehavior(border_rect, window->GetID((void*)(intptr_t)(border_n + 4)), &hovered, &held, ImGuiButtonFlags_FlattenChildren);
         if ((hovered && g.HoveredIdTimer > BORDER_APPEAR_TIMER) || held)


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**2 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `examples/common/imgui/imgui.cpp` 
Enclosing Function : `UpdateManualResize@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/lighttransport/nanort/blob/135a452385a2903592db7518fbb80479d99ab9c3/examples/common/imgui/imgui.cpp#L4405
**Issue in**: _held, hovered_

**Code extract**:

```cpp
        if (resize_rect.Min.x > resize_rect.Max.x) ImSwap(resize_rect.Min.x, resize_rect.Max.x);
        if (resize_rect.Min.y > resize_rect.Max.y) ImSwap(resize_rect.Min.y, resize_rect.Max.y);
        bool hovered, held;
        ButtonBehavior(resize_rect, window->GetID((void*)(intptr_t)resize_grip_n), &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_NoNavFocus); <------ HERE
        if (hovered || held)
            g.MouseCursor = (resize_grip_n & 1) ? ImGuiMouseCursor_ResizeNESW : ImGuiMouseCursor_ResizeNWSE;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `examples/common/imgui/imgui.cpp` 
Enclosing Function : `UpdateManualResize@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/lighttransport/nanort/blob/135a452385a2903592db7518fbb80479d99ab9c3/examples/common/imgui/imgui.cpp#L4431
**Issue in**: _held, hovered_

**Code extract**:

```cpp
        const float BORDER_APPEAR_TIMER = 0.05f; // Reduce visual noise
        bool hovered, held;
        ImRect border_rect = GetResizeBorderRect(window, border_n, grip_hover_size, BORDER_SIZE);
        ButtonBehavior(border_rect, window->GetID((void*)(intptr_t)(border_n + 4)), &hovered, &held, ImGuiButtonFlags_FlattenChildren); <------ HERE
        if ((hovered && g.HoveredIdTimer > BORDER_APPEAR_TIMER) || held)
        {
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
