### PR TITLE
modernized CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,26 @@
-cmake_minimum_required(VERSION 2.8.0)
-project(nanort)
+cmake_minimum_required(VERSION 3.1)
+
+set(CMAKE_BUILD_TYPE_INIT "Release")
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+project(nanort LANGUAGES C CXX)
 
 # ------------------------------------------------------------------------------
 # C++ settings
 # ------------------------------------------------------------------------------
 if (MSVC)
   # Increase compiler warning level.
-  set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
 endif()
 
 if (NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O2 -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wall")
 endif()
 
-# ------------------------------------------------------------------------------
-# OpenMP
-# ------------------------------------------------------------------------------
-find_package(OpenMP)
-if (OPENMP_FOUND)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif()
+set(nanort_DIR ${CMAKE_SOURCE_DIR})
+find_package(nanort REQUIRED)
 
 # ------------------------------------------------------------------------------
 # Output directories

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(common)
+
 add_subdirectory(bidir_path_tracer)
 add_subdirectory(gui)
 add_subdirectory(path_tracer)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,4 +2,5 @@ add_subdirectory(common)
 
 add_subdirectory(bidir_path_tracer)
 add_subdirectory(gui)
+add_subdirectory(nanosg)
 add_subdirectory(path_tracer)

--- a/examples/bidir_path_tracer/CMakeLists.txt
+++ b/examples/bidir_path_tracer/CMakeLists.txt
@@ -1,10 +1,8 @@
 set(BUILD_TARGET "bidir_path_tracer")
 
-include_directories(${CMAKE_SOURCE_DIR})
-include_directories("../common")
-
 file(GLOB SOURCES "*.cc" "*.h")
 add_executable(${BUILD_TARGET} ${SOURCES})
+target_link_libraries(${BUILD_TARGET} PRIVATE nanort::nanort tinyexr)
 
 source_group("Source Files" FILES ${SOURCES})
 

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -1,0 +1,54 @@
+
+## glew ##
+
+add_library(glew STATIC ThirdPartyLibs/Glew/glew.c)
+target_compile_definitions(glew PUBLIC -DGLEW_STATIC)
+target_include_directories(glew PUBLIC ThirdPartyLibs/Glew)
+
+## tinyexr ##
+add_library(tinyexr INTERFACE)
+target_include_directories(tinyexr INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+## trackball ##
+
+add_library(trackball STATIC trackball.cc)
+target_include_directories(trackball PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+
+## windowing ##
+
+set(OpenGL_GL_PREFERENCE "LEGACY")
+find_package(OpenGL REQUIRED)
+
+if(WIN32)
+    set(SOURCES OpenGLWindow/Win32OpenGLWindow.cpp OpenGLWindow/Win32Window.cpp)
+elseif(APPLE)
+    find_library(COCOA Cocoa REQUIRED)
+    set(SOURCES OpenGLWindow/MacOpenGLWindow.mm)
+    set(LIBS ${COCOA})
+else()
+    find_package(X11 REQUIRED)
+    set(SOURCES OpenGLWindow/X11OpenGLWindow.cpp)
+    set(LIBS ${X11_LIBRARIES})
+    set(INCLUDES ${X11_INCLUDE_DIR})
+endif()
+
+add_library(windowing STATIC ${SOURCES})
+target_link_libraries(windowing PUBLIC OpenGL::GL glew PRIVATE ${LIBS})
+target_include_directories(windowing
+PUBLIC
+  ${CMAKE_CURRENT_LIST_DIR}
+PRIVATE
+  ${INCLUDES}
+)
+
+## ImGui ##
+
+add_library(imgui STATIC
+  imgui/imgui.cpp
+  imgui/imgui_draw.cpp
+  imgui/imgui_impl_btgui.cpp
+  imgui/imgui_widgets.cpp
+)
+
+target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_LIST_DIR}/imgui)
+target_link_libraries(imgui PUBLIC windowing)

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -6,13 +6,24 @@ target_compile_definitions(glew PUBLIC -DGLEW_STATIC)
 target_include_directories(glew PUBLIC ThirdPartyLibs/Glew)
 
 ## tinyexr ##
+
 add_library(tinyexr INTERFACE)
 target_include_directories(tinyexr INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+## glm ##
+
+add_library(glm INTERFACE)
+target_include_directories(glm INTERFACE ${CMAKE_CURRENT_LIST_DIR}/glm)
 
 ## trackball ##
 
 add_library(trackball STATIC trackball.cc)
 target_include_directories(trackball PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+
+## matrix ##
+
+add_library(matrix STATIC matrix.cc)
+target_include_directories(matrix PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
 ## windowing ##
 
@@ -48,6 +59,7 @@ add_library(imgui STATIC
   imgui/imgui_draw.cpp
   imgui/imgui_impl_btgui.cpp
   imgui/imgui_widgets.cpp
+  imgui/ImGuizmo.cpp
 )
 
 target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_LIST_DIR}/imgui)

--- a/examples/gui/CMakeLists.txt
+++ b/examples/gui/CMakeLists.txt
@@ -1,71 +1,15 @@
-cmake_minimum_required(VERSION 3.5.1)
 
 set(BUILD_TARGET "gui")
-
-find_package(OpenGL REQUIRED)
-
-if(WIN32)
-    # nothing.
-elseif(APPLE)
-    find_library(COCOA Cocoa REQUIRED)
-else()
-    find_package(X11 REQUIRED)
-endif()
-
-include_directories(${OPENGL_INCLUDE_DIR})
-include_directories(${X11_INCLUDE_DIR})
-
-include_directories(${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/examples/common")
-include_directories(${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/examples/common/imgui")
-
-# local Glew
-include_directories(${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/examples/common/ThirdPartyLibs/Glew")
-add_definitions("-DGLEW_STATIC")
 
 set(SOURCES
     main.cc
     render.cc
     render-config.cc
-    ../common/trackball.cc
     matrix.cc
-    ../common/imgui/imgui.cpp
-    ../common/imgui/imgui_draw.cpp
-    ../common/imgui/imgui_impl_btgui.cpp
-    ../common/imgui/imgui_widgets.cpp
 )
-
-if(WIN32)
-    set(SOURCES ${SOURCES}
-        ../common/OpenGLWindow/Win32OpenGLWindow.cpp
-        ../common/OpenGLWindow/Win32Window.cpp
-    )
-elseif(APPLE)
-    set(SOURCES ${SOURCES} ../common/OpenGLWindow/MacOpenGLWindow.mm)
-else()
-    set(SOURCES ${SOURCES} ../common/OpenGLWindow/X11OpenGLWindow.cpp)
-endif()
-
-set(SOURCES ${SOURCES} ../common/ThirdPartyLibs/Glew/glew.c)
 
 add_executable(${BUILD_TARGET} ${SOURCES})
 
-target_link_libraries(
-    ${BUILD_TARGET}
-    ${OPENGL_LIBRARIES}
-)
-
-if(WIN32)
-    # nothing.
-elseif(APPLE)
-    target_link_libraries(
-        ${BUILD_TARGET}
-        ${COCOA}
-    )
-else()
-    target_link_libraries(
-        ${BUILD_TARGET}
-        ${X11_LIBRARIES}
-    )
-endif()
+target_link_libraries(${BUILD_TARGET} PRIVATE nanort::nanort imgui trackball)
 
 source_group("Source Files" FILES ${SOURCES})

--- a/examples/nanosg/CMakeLists.txt
+++ b/examples/nanosg/CMakeLists.txt
@@ -1,79 +1,21 @@
-cmake_minimum_required(VERSION 3.5.1)
-
 set(BUILD_TARGET "nanosg")
-
-find_package(OpenGL REQUIRED)
-find_package(Threads REQUIRED)
-
-if(WIN32)
-    # nothing.
-elseif(APPLE)
-    find_library(COCOA Cocoa REQUIRED)
-else()
-    find_package(X11 REQUIRED)
-endif()
 
 set(SOURCES
     main.cc
     render.cc
     render-config.cc
     obj-loader.cc
-    ../common/trackball.cc
-    ../common/matrix.cc
-    ../common/imgui/imgui.cpp
-    ../common/imgui/imgui_draw.cpp
-    ../common/imgui/imgui_impl_btgui.cpp
-    ../common/imgui/imgui_widgets.cpp
-    ../common/imgui/ImGuizmo.cpp
 )
-
-if(WIN32)
-    set(SOURCES ${SOURCES}
-        ../common/OpenGLWindow/Win32OpenGLWindow.cpp
-        ../common/OpenGLWindow/Win32Window.cpp
-    )
-elseif(APPLE)
-    set(SOURCES ${SOURCES} ../common/OpenGLWindow/MacOpenGLWindow.mm)
-else()
-    set(SOURCES ${SOURCES} ../common/OpenGLWindow/X11OpenGLWindow.cpp)
-endif()
-
-set(SOURCES ${SOURCES} ../common/ThirdPartyLibs/Glew/glew.c)
 
 add_executable(${BUILD_TARGET} ${SOURCES})
 
-target_include_directories(${BUILD_TARGET} PRIVATE ${OPENGL_INCLUDE_DIR})
-target_include_directories(${BUILD_TARGET} PRIVATE ${X11_INCLUDE_DIR})
-
-target_include_directories(${BUILD_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../)
-target_include_directories(${BUILD_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(${BUILD_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../common")
-target_include_directories(${BUILD_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../common/glm")
-target_include_directories(${BUILD_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../common/imgui")
-
-# local Glew
-target_include_directories(${BUILD_TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/../common/ThirdPartyLibs/Glew")
-target_compile_definitions(${BUILD_TARGET} PRIVATE GLEW_STATIC)
-
-
-target_link_libraries(
-    ${BUILD_TARGET}
-    ${OPENGL_LIBRARIES}
-    Threads::Threads
+target_link_libraries( ${BUILD_TARGET}
+PRIVATE
+    nanort::nanort
+    imgui
+    trackball
+    matrix
+    glm
 )
-
-if(WIN32)
-    # nothing.
-elseif(APPLE)
-    target_link_libraries(
-        ${BUILD_TARGET}
-        ${COCOA}
-    )
-else()
-    target_link_libraries(
-        ${BUILD_TARGET}
-        ${X11_LIBRARIES}
-    )
-endif()
 
 source_group("Source Files" FILES ${SOURCES})

--- a/examples/path_tracer/CMakeLists.txt
+++ b/examples/path_tracer/CMakeLists.txt
@@ -1,8 +1,7 @@
 set(BUILD_TARGET "path_tracer")
 
-include_directories(${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/examples/common")
-
 file(GLOB SOURCES "*.cc" "*.h")
 add_executable(${BUILD_TARGET} ${SOURCES})
+target_link_libraries(${BUILD_TARGET} PRIVATE nanort::nanort tinyexr)
 
 source_group("Source Files" FILES ${SOURCES})

--- a/nanortConfig.cmake
+++ b/nanortConfig.cmake
@@ -1,0 +1,105 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 Light Transport Entertainment, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+cmake_minimum_required(VERSION 3.1)
+
+if (TARGET nanort::nanort)
+  return()
+endif()
+
+macro(nanort_config_message)
+  if (NOT DEFINED nanort_FIND_QUIETLY)
+    message(${ARGN})
+  endif()
+endmacro()
+
+## Setup base target ##
+
+add_library(nanort::core INTERFACE IMPORTED)
+target_include_directories(nanort::core INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+nanort_config_message(STATUS "Found nanort: ${CMAKE_CURRENT_LIST_DIR}")
+nanort_config_message("    --> nanort core target available (nanort::core)")
+
+## Setup target which uses C++11 threads ##
+
+find_package(Threads QUIET)
+if (TARGET Threads::Threads)
+  add_library(nanort::threads INTERFACE IMPORTED)
+
+  target_compile_features(nanort::threads
+  INTERFACE
+    cxx_std_11
+  )
+
+  target_link_libraries(nanort::threads
+  INTERFACE
+    Threads::Threads
+    nanort::core
+  )
+
+  target_compile_definitions(nanort::threads
+  INTERFACE
+    -DNANORT_USE_CPP11_FEATURE
+    -DNANORT_ENABLE_PARALLEL_BUILD
+  )
+
+  nanort_config_message("    --> nanort C++11 threading target available (nanort::threads)")
+else()
+  nanort_config_message(WARNING "nanort C++11 threading target NOT available! (unable to find Threads)")
+endif()
+
+## Setup target which uses OpenMP ##
+
+find_package(OpenMP QUIET)
+if (TARGET OpenMP::OpenMP_CXX)
+  add_library(nanort::openmp INTERFACE IMPORTED)
+
+  target_link_libraries(nanort::openmp
+  INTERFACE
+    nanort::core
+    OpenMP::OpenMP_CXX
+  )
+
+  target_compile_definitions(nanort::openmp
+  INTERFACE
+    -DNANORT_ENABLE_PARALLEL_BUILD
+  )
+
+  nanort_config_message("    --> nanort OpenMP target available (nanort::openmp)")
+else()
+  nanort_config_message(WARNING "nanort OpenMP target NOT available! (unable to find OpenMP)")
+endif()
+
+## Setup a target which uses the "best" available version ##
+
+add_library(nanort::nanort INTERFACE IMPORTED)
+if (TARGET nanort::openmp)
+  target_link_libraries(nanort::nanort INTERFACE nanort::openmp)
+  nanort_config_message("    --> default target (nanort::nanort) uses OpenMP")
+elseif (TARGET nanort::threads)
+  target_link_libraries(nanort::nanort INTERFACE nanort::threads)
+  nanort_config_message("    --> default target (nanort::nanort) uses C++11 threads")
+else()
+  target_link_libraries(nanort::nanort INTERFACE nanort::core)
+  nanort_config_message("    --> default target (nanort::nanort) uses only core nanort")
+endif()


### PR DESCRIPTION
This PR adds a `nanortConfig.cmake` and then uses it in the local examples which are built with CMake. The config works like any other CMake package config, where

`find_package(nanort)`

...generates the following targets:

- `nanort::core` --> use only the "base" version of nanort
- `nanort::threads` --> use nanort with C++11 threads enabled
- `nanort::openmp` --> use nanort with OpenMP enabled
- `nanort::nanort` --> a target which selects OpenMP/threads/core (in that order) depending on what is available

The config requires CMake >= 3.9 to get the target-based version of CMake's `find_package(OpenMP)` support.

I ended up getting slightly carried away with further modernizations to the examples, which are stand alone commits to adding the config.

Let me know if this looks helpful/good and if you would like to see any revisions.