### PR TITLE
Make it compilable with C++20

### DIFF
--- a/nanort.h
+++ b/nanort.h
@@ -198,7 +198,11 @@ class StackAllocator : public std::allocator<T> {
       source_->used_stack_buffer_ = true;
       return source_->stack_buffer();
     } else {
+#if __cplusplus >= 201703L
+      return std::allocator_traits<std::allocator<T>>::allocate(*this, n, hint);
+#else
       return std::allocator<T>::allocate(n, hint);
+#endif
     }
   }
 

--- a/nanort.h
+++ b/nanort.h
@@ -130,7 +130,7 @@ typedef enum {
 template <typename T, size_t stack_capacity>
 class StackAllocator : public std::allocator<T> {
  public:
-  typedef typename std::allocator<T>::pointer pointer;
+  typedef T* pointer;
   typedef typename std::allocator<T>::size_type size_type;
 
   // Backing store for the allocator. The container owner is responsible for


### PR DESCRIPTION
The following code will trigger a compile error when using C++20.

```
#include "nanort.h"

int main()
{
  nanort::StackVector<double, 100> v;
}
```

This is because 'nanort.h' uses the following, which have been removed in C++20 (deprecated since C++17).

* `std::allocator<T>::pointer`
* `std::allocator<T>::allocate(size_type n, const void* hint)`

This PR make changes to avoid using there.

This will allow the code shown at the beginning to compile using C++20.
